### PR TITLE
V0.4.2 318 extract search

### DIFF
--- a/opal/core/search/static/js/search/controllers/extract.js
+++ b/opal/core/search/static/js/search/controllers/extract.js
@@ -106,7 +106,7 @@ angular.module('opal.controllers').controller(
         };
 
         $scope.removeCriteria = function(){
-            $scope.criteria.splice(0, $scope.criteria.length-1);
+            $scope.criteria = [_.clone($scope.model)];
         }
 
         //

--- a/opal/core/search/static/js/search/controllers/extract.js
+++ b/opal/core/search/static/js/search/controllers/extract.js
@@ -24,7 +24,7 @@ angular.module('opal.controllers').controller(
             combine    : "and",
             column     : null,
             field      : null,
-            queryType  : "Equals",
+            queryType  : null,
             query      : null,
             lookup_list: []
         };

--- a/opal/core/search/templates/extract.html
+++ b/opal/core/search/templates/extract.html
@@ -11,44 +11,39 @@
     <div class="panel-body">
 
       <div class="row">
-        <div class="col-md-10">
+        <div class="col-md-9">
           <form class="form form-inline">
             <span ng-repeat="query in criteria">
               <div class="row">
-                  <div class="col-md-3">
-                    <select class="form-control content-offset-25 content-offset-below-25" ng-model="query.combine"
-                            ng-hide="$index == 0">
+                  <div class="col-md-3" ng-hide="$index == 0">
+                    <select class="content-offset-20 content-offset-below-20 form-control" ng-model="query.combine">
                       <option>and</option>
                       <option>or</option>
                     </select>
                   </div>
               </div>
               <div class="row">
-                <div class="col-md-3">
+                <div class="col-md-10">
                   <select class="form-control" ng-model="query.column"
                   ng-change="resetFilter($index, ['combine', 'column'])"
+                  data-trigger="focus" bs-tooltip="tooltip"
+                  data-placement="top" data-title="1. Select a Column"
+                  set-focus-if="!query.column"
                   >
                     <option ng-repeat="col in columns" value="[[col.name]]">
                       [[col.display_name]]
                     </option>
                   </select>
-                  <p ng-show="query.column == null">
-                    1. Select a Column
-                  </p>
-                </div>
-                <div class="col-md-2">
                   <span ng-repeat="col in columns"
                         ng-show="query.column == col.name">
-                    <select class="form-control" ng-model="query.field" >
+                    <select class="form-control" ng-model="query.field"
+                    data-trigger="focus" bs-tooltip="tooltip"
+                    data-placement="top" data-title="2. Select a field"
+                    set-focus-if="query.field == null && query.column != null"
+                    >
                       <option ng-repeat="field in searchableFields(col)">[[field]]</option>
                     </select>
                   </span>
-                  <p ng-show="query.column != null && query.field == null">
-                    2. Select a field
-                  </p>
-                </div>
-                <div class="col-md-4" ng-show="query.column == 'tagging'"></div>
-                <div class="col-md-2" ng-hide="query.column == 'tagging'">
                   <select class="form-control"
                           ng-show="query.field != null && !isDate(query.column, query.field)"
                           ng-model="query.queryType" >
@@ -57,16 +52,18 @@
                   </select>
                   <select class="form-control"
                           ng-show="query.field != null && isDate(query.column, query.field)"
-                          ng-model="query.queryType" >
+                          ng-model="query.queryType" data-trigger="focus" bs-tooltip="tooltip"
+                          data-placement="top" data-title="4. Add your value"
+                          set-focus-if="query.field != null && isDate(query.column, query.field)" >
                     <option>Before</option>
                     <option>After</option>
                   </select>
-                  <p ng-show="query.column != null && query.field != null && query.queryType == null">
-                    3. Select a query type
-                  </p>
-                </div>
-                <div class="col-md-2" ng-hide="query.column == 'tagging'">
-                  <select class="form-control" ng-model="query.query" ng-show="isBoolean(query.column, query.field) && query.field != null">
+                  <select class="form-control" ng-model="query.query"
+                          ng-show="isBoolean(query.column, query.field) && query.field != null"
+                          data-trigger="focus" bs-tooltip="tooltip"
+                          data-placement="top" data-title="4. Add your value"
+                          set-focus-if="isBoolean(query.column, query.field) && query.field != null"
+                          >
                     <option>true</option>
                     <option>false</option>
                   </select>
@@ -75,20 +72,22 @@
                          ng-model="query.query"
                          ng-show="isText(query.column, query.field) && query.field != null"
                          ng-options="x for x in query.lookup_list"
+                         data-trigger="focus" bs-tooltip="tooltip"
+                         data-placement="top" data-title="4. Add your value"
+                         set-focus-if="isText(query.column, query.field) && query.field != null"
                          bs-typeahead
                          />
                 <input type="text" ng-model="query.query"
                          class="form-control"
                          ng-show="isDate(query.column, query.field) && query.field != null"
-  	               ng-pattern="/^(0?[1-9]|[12][0-9]|3[01])\/(0?[1-9]|1[012])\/(\d{4})$/"
-  	               placeholder="dd/mm/yyyy"
+                         data-trigger="focus" bs-tooltip="tooltip"
+                         data-placement="top" data-title="4. Add your value"
+        	               ng-pattern="/^(0?[1-9]|[12][0-9]|3[01])\/(0?[1-9]|1[012])\/(\d{4})$/"
+        	               placeholder="dd/mm/yyyy"
+                         set-focus-if="isDate(query.column, query.field) && query.field != null"
                          />
-
-                  <p ng-show="query.queryType != null && query.query == null && query.field != null">
-                    4. Add your value
-                  </p>
                 </div>
-                <div class="col-md-3 text-center">
+                <div class="col-md-2">
                   <button type="button" class="btn btn-success"
                           ng-show="query.field != null"
                           ng-click="addFilter()"
@@ -100,77 +99,75 @@
                           ng-click="removeFilter($index)"
                           >
                     <span ng-click="removeFilter($index)" class="glyphicon glyphicon-minus"></span>
-                </button>        </div>
+                  </button>
+                </div>
               </div>
             </span>
-
+            <div class="content-offset-20 ">
+              <button class="btn btn-danger" ng-show="criteria.length > 1" ng-click="removeCriteria()">
+                 Clear search
+               </button>
+           </div>
           </form>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-3">
           <div class="panel panel-default">
             <div class="panel-heading">
-              <h4><i class="fa fa-save"></i> Searches</h4>
+              <h4><i class="fa fa-save saved-search"></i>Saved Searches</h4>
             </div>
-            <ul class="list-group">
-              <li class="list-group-item" ng-repeat="f in filters">
-                <a href="#" ng-click="jumpToFilter($event, f)">
-                  [[f.name]]
-                </a>
-                <a href="#" ng-click="editFilter($event, f, $index)" >
-                  <span class="glyphicon glyphicon-edit"></span>
-                </a>
-              </li>
-            </ul>
 
+            <div class="panel-body">
+              <ul ng-show="filters.length" class="list-group">
+                <li class="list-group-item" ng-repeat="f in filters">
+                  <strong>
+                    <a href="#" ng-click="jumpToFilter($event, f)">
+                      [[f.name]]
+                    </a>
+                    <a href="#" ng-click="editFilter($event, f, $index)" >
+                      <span class="glyphicon glyphicon-edit"></span>
+                    </a>
+                  </strong>
+                </li>
+              </ul>
+              <div ng-show="!filters.length">
+                You have no saved searches
+              </div>
+            </div>
+            <div ng-show="results.length > 0" class="panel-footer text-center">
+              <button type="button"
+                      class="btn btn-secondary"
+                      ng-click="save()"
+                      >
+                <span class="glyphicon glyphicon-floppy-disk"></span>
+                Save this search
+              </button>
+            </div>
           </div>
         </div>
-      </div> <!-- Row -->
-      <br />
-      <div class="row">
-        <div class="col-md-5 col-md-offset-3">
-
-          <form action="/search/extract/download" method="post" target="_blank"
-                 ng-show="profile.can_extract"
-                >
-            <input name="criteria" type="hidden" value="[[ JSON.stringify(criteria) ]]">
-            {% csrf_token %}
-            <button type="submit"
-                    class="btn btn-secondary pull-left"
-                    ng-show="results.length > 0">
-              <span class="glyphicon glyphicon-download"></span>
-              Download these results
-            </button>
-          </form>
-
-          <button type="button"
-                  class="btn btn-secondary pull-left push-left-12"
-                  ng-click="save()"
-                  ng-show="results.length > 0">
-
-            <span class="glyphicon glyphicon-floppy-disk"></span>
-            Save this search
-          </button>
-
-
-        </div>
-        <div class="col-md-4">
-          <button class="btn btn-danger" ng-show="criteria.length > 1" ng-click="removeCriteria()">
-                Clear search
-          </button>
-          <button type="button"
-                  class="btn btn-primary"
-                  ng-click="search()"
-                  >
-            <span class="glyphicon glyphicon-search"></span>
-            Search
-          </button>
-          <a href="#/search" class="btn btn-secondary">
-            <i class="fa fa-arrow-circle-right"></i>
-            Basic
-          </a>
-        </div>
       </div>
-    </div>
+      <div class="row">
+        <button type="button"
+                class="btn btn-primary col-md-4 col-md-push-4"
+                ng-click="search()"
+                >
+          <span class="glyphicon glyphicon-search"></span>
+          Search
+        </button>
+      </div>
+      <div class="row content-offset-25" ng-show="!profile.can_extract">
+        <form action="/search/extract/download" method="post" target="_blank">
+          <input name="criteria" type="hidden" value="[[ JSON.stringify(criteria) ]]">
+          {% csrf_token %}
+          <button type="submit"
+                  class="btn btn-secondary col-md-4 col-md-push-4"
+                  ng-show="results.length > 0">
+            <span class="glyphicon glyphicon-download"></span>
+            Download these results
+          </button>
+        </form>
+      </div>
+      <br />
+    </div> <!-- Row -->
 
     <div ng-show="results.length == 0">
       <p>

--- a/opal/core/search/templates/extract.html
+++ b/opal/core/search/templates/extract.html
@@ -168,14 +168,15 @@
       </div>
       <br />
     </div> <!-- Row -->
-
-    <div ng-show="results.length == 0">
-      <p>
-        Sorry, no results match your search.
-      </p>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="col-md-12" ng-show="results.length == 0">
+          <p>
+            Sorry, no results match your search.
+          </p>
+        </div>
+      </div>
     </div>
-
-
     {% include 'partials/_episode_summary_table.html' %}
     <!-- Table -->
   </div>

--- a/opal/core/search/templates/extract.html
+++ b/opal/core/search/templates/extract.html
@@ -9,161 +9,165 @@
       </h2>
     </div>
     <div class="panel-body">
-
-      <div class="row">
-        <div class="col-md-9">
-          <form class="form form-inline">
-            <span ng-repeat="query in criteria">
-              <div class="row">
-                  <div class="col-md-3" ng-hide="$index == 0">
-                    <select class="content-offset-20 content-offset-below-20 form-control" ng-model="query.combine">
-                      <option>and</option>
-                      <option>or</option>
-                    </select>
-                  </div>
-              </div>
-              <div class="row">
-                <div class="col-md-10">
-                  <select class="form-control" ng-model="query.column"
-                  ng-change="resetFilter($index, ['combine', 'column'])"
-                  data-trigger="focus" bs-tooltip="tooltip"
-                  data-placement="top" data-title="1. Select a Column"
-                  set-focus-if="!query.column"
-                  >
-                    <option ng-repeat="col in columns" value="[[col.name]]">
-                      [[col.display_name]]
-                    </option>
-                  </select>
-                  <span ng-repeat="col in columns"
-                        ng-show="query.column == col.name">
-                    <select class="form-control" ng-model="query.field"
+      <form class="form form-inline" ng-submit="search()">
+        <div class="row">
+          <div class="col-md-9">
+              <span ng-repeat="query in criteria">
+                <div class="row">
+                    <div class="col-md-3" ng-hide="$index == 0">
+                      <select class="content-offset-10 content-offset-below-20 form-control" ng-model="query.combine">
+                        <option>and</option>
+                        <option>or</option>
+                      </select>
+                    </div>
+                </div>
+                <div class="row">
+                  <div class="col-md-10">
+                    <select class="form-control content-offset-below-10" ng-model="query.column"
+                    ng-change="resetFilter($index, ['combine', 'column'])"
                     data-trigger="focus" bs-tooltip="tooltip"
-                    data-placement="top" data-title="2. Select a field"
-                    set-focus-if="query.field == null && query.column != null"
+                    data-placement="top" data-title="1. Select a Column"
+                    set-focus-if="!query.column"
                     >
-                      <option ng-repeat="field in searchableFields(col)">[[field]]</option>
+                      <option ng-repeat="col in columns" value="[[col.name]]">
+                        [[col.display_name]]
+                      </option>
                     </select>
-                  </span>
-                  <select class="form-control"
-                          ng-show="query.field != null && !isDate(query.column, query.field)"
-                          ng-model="query.queryType" >
-                    <option>Equals</option>
-                    <option ng-show="isText(query.column, query.field)">Contains</option>
-                  </select>
-                  <select class="form-control"
-                          ng-show="query.field != null && isDate(query.column, query.field)"
-                          ng-model="query.queryType" data-trigger="focus" bs-tooltip="tooltip"
-                          data-placement="top" data-title="4. Add your value"
-                          set-focus-if="query.field != null && isDate(query.column, query.field)" >
-                    <option>Before</option>
-                    <option>After</option>
-                  </select>
-                  <select class="form-control" ng-model="query.query"
-                          ng-show="isBoolean(query.column, query.field) && query.field != null"
-                          data-trigger="focus" bs-tooltip="tooltip"
-                          data-placement="top" data-title="4. Add your value"
-                          set-focus-if="isBoolean(query.column, query.field) && query.field != null"
-                          >
-                    <option>true</option>
-                    <option>false</option>
-                  </select>
-                  <input type="text"
-                         class="form-control"
-                         ng-model="query.query"
-                         ng-show="isText(query.column, query.field) && query.field != null"
-                         ng-options="x for x in query.lookup_list"
-                         data-trigger="focus" bs-tooltip="tooltip"
-                         data-placement="top" data-title="4. Add your value"
-                         set-focus-if="isText(query.column, query.field) && query.field != null"
-                         bs-typeahead
-                         />
-                <input type="text" ng-model="query.query"
-                         class="form-control"
-                         ng-show="isDate(query.column, query.field) && query.field != null"
-                         data-trigger="focus" bs-tooltip="tooltip"
-                         data-placement="top" data-title="4. Add your value"
-        	               ng-pattern="/^(0?[1-9]|[12][0-9]|3[01])\/(0?[1-9]|1[012])\/(\d{4})$/"
-        	               placeholder="dd/mm/yyyy"
-                         set-focus-if="isDate(query.column, query.field) && query.field != null"
-                         />
-                </div>
-                <div class="col-md-2">
-                  <button type="button" class="btn btn-success"
-                          ng-show="query.field != null"
-                          ng-click="addFilter()"
-                          >
-                    <span ng-click="addFilter" class="glyphicon glyphicon-plus"></span>
-                  </button>
-                  <button type="button" class="btn btn-danger"
-                          ng-show="(query.field != null && criteria.length > 1 || criteria.length > 1)"
-                          ng-click="removeFilter($index)"
-                          >
-                    <span ng-click="removeFilter($index)" class="glyphicon glyphicon-minus"></span>
-                  </button>
-                </div>
-              </div>
-            </span>
-            <div class="content-offset-20 ">
-              <button class="btn btn-danger" ng-show="criteria.length > 1" ng-click="removeCriteria()">
-                 Clear search
-               </button>
-           </div>
-          </form>
-        </div>
-        <div class="col-md-3">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h4><i class="fa fa-save saved-search"></i>Saved Searches</h4>
-            </div>
-
-            <div class="panel-body">
-              <ul ng-show="filters.length" class="list-group">
-                <li class="list-group-item" ng-repeat="f in filters">
-                  <strong>
-                    <a href="#" ng-click="jumpToFilter($event, f)">
-                      [[f.name]]
-                    </a>
-                    <a href="#" ng-click="editFilter($event, f, $index)" >
-                      <span class="glyphicon glyphicon-edit"></span>
-                    </a>
-                  </strong>
-                </li>
-              </ul>
-              <div ng-show="!filters.length">
-                You have no saved searches
-              </div>
-            </div>
-            <div ng-show="results.length > 0" class="panel-footer text-center">
-              <button type="button"
-                      class="btn btn-secondary"
-                      ng-click="save()"
+                    <span ng-repeat="col in columns"
+                          ng-show="query.column == col.name">
+                      <select class="form-control content-offset-below-10" ng-model="query.field"
+                      data-trigger="focus" bs-tooltip="tooltip"
+                      data-placement="top" data-title="2. Select a field"
+                      set-focus-if="query.field == null && query.column != null"
                       >
-                <span class="glyphicon glyphicon-floppy-disk"></span>
-                Save this search
-              </button>
+                        <option ng-repeat="field in searchableFields(col)">[[field]]</option>
+                      </select>
+                    </span>
+                    <span ng-if="query.column != 'tagging'">
+                      <select class="form-control content-offset-below-10"
+                              ng-if="query.field != null && !isDate(query.column, query.field)"
+                              ng-model="query.queryType" >
+                        <option>Equals</option>
+                        <option ng-show="isText(query.column, query.field)">Contains</option>
+                      </select>
+                      <select class="form-control content-offset-below-10"
+                                ng-if="query.field != null && isDate(query.column, query.field)"
+                              ng-model="query.queryType" data-trigger="focus" bs-tooltip="tooltip"
+                              data-placement="top" data-title="3. Select your query type"
+                              set-focus-if="query.field != null && isDate(query.column, query.field)" >
+                        <option>Before</option>
+                        <option>After</option>
+                      </select>
+                      <select class="form-control content-offset-below-10" ng-model="query.query"
+                              ng-if="isBoolean(query.column, query.field) && query.field != null"
+                              data-trigger="focus" bs-tooltip="tooltip"
+                              data-placement="top" data-title="3. Select your query type"
+                              set-focus-if="isBoolean(query.column, query.field) && query.field != null"
+                              >
+                        <option>true</option>
+                        <option>false</option>
+                      </select>
+                      <input type="text"
+                             class="form-control content-offset-below-10"
+                             ng-model="query.query"
+                             ng-if="isText(query.column, query.field) && query.field != null"
+                             ng-options="x for x in query.lookup_list"
+                             data-trigger="focus" bs-tooltip="tooltip"
+                             data-placement="top" data-title="4. Add your value"
+                             set-focus-if="isText(query.column, query.field) && query.field != null"
+                             bs-typeahead
+                             />
+                    <input type="text" ng-model="query.query"
+                             class="form-control content-offset-below-10"
+                             ng-if="isDate(query.column, query.field) && query.field != null"
+                             data-trigger="focus" bs-tooltip="tooltip"
+                             data-placement="top" data-title="4. Add your value"
+            	               ng-pattern="/^(0?[1-9]|[12][0-9]|3[01])\/(0?[1-9]|1[012])\/(\d{4})$/"
+            	               placeholder="dd/mm/yyyy"
+                             set-focus-if="isDate(query.column, query.field) && query.field != null && query.queryType != null"
+                             />
+                    </div>
+                  </span>
+                  <div class="col-md-2">
+                    <button type="button" class="btn btn-success content-offset-below-10"
+                            ng-show="query.field != null"
+                            ng-click="addFilter()"
+                            >
+                      <span ng-click="addFilter" class="glyphicon glyphicon-plus"></span>
+                    </button>
+                    <button type="button" class="btn btn-danger content-offset-below-10"
+                            ng-show="(query.field != null && criteria.length > 1 || criteria.length > 1)"
+                            ng-click="removeFilter($index)"
+                            >
+                      <span ng-click="removeFilter($index)" class="glyphicon glyphicon-minus"></span>
+                    </button>
+                  </div>
+                </div>
+              </span>
+              <div class="content-offset-20 ">
+                <a class="btn btn-danger" ng-show="criteria.length > 1" ng-click="removeCriteria()">
+                   Clear search
+                 </a>
+             </div>
+          </div>
+          <div class="col-md-3">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4><i class="fa fa-save saved-search"></i>Saved Searches</h4>
+              </div>
+
+              <div class="panel-body">
+                <ul ng-show="filters.length" class="list-group">
+                  <li class="list-group-item" ng-repeat="f in filters">
+                    <strong>
+                      <a href="#" ng-click="jumpToFilter($event, f)">
+                        [[f.name]]
+                      </a>
+                      <a href="#" ng-click="editFilter($event, f, $index)" >
+                        <span class="glyphicon glyphicon-edit"></span>
+                      </a>
+                    </strong>
+                  </li>
+                </ul>
+                <div ng-show="!filters.length">
+                  You have no saved searches
+                </div>
+              </div>
+              <div ng-show="results.length > 0" class="panel-footer text-center">
+                <button type="button"
+                        class="btn btn-secondary"
+                        ng-click="save()"
+                        >
+                  <span class="glyphicon glyphicon-floppy-disk"></span>
+                  Save this search
+                </button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="row">
-        <button type="button"
-                class="btn btn-primary col-md-4 col-md-push-4"
-                ng-click="search()"
-                >
-          <span class="glyphicon glyphicon-search"></span>
-          Search
-        </button>
-      </div>
+        <div class="row">
+          <div class="col-md-12">
+            <button type="submit"
+                    class="btn btn-primary col-md-4 col-md-push-4"
+                    >
+              <span class="glyphicon glyphicon-search"></span>
+              Search
+            </button>
+          </div>
+        </div>
+      </form>
       <div class="row content-offset-25" ng-show="!profile.can_extract">
         <form action="/search/extract/download" method="post" target="_blank">
           <input name="criteria" type="hidden" value="[[ JSON.stringify(criteria) ]]">
           {% csrf_token %}
-          <button type="submit"
-                  class="btn btn-secondary col-md-4 col-md-push-4"
-                  ng-show="results.length > 0">
-            <span class="glyphicon glyphicon-download"></span>
-            Download these results
-          </button>
+          <div class="col-md-12">
+            <button type="submit"
+                    class="btn btn-secondary col-md-4 col-md-push-4"
+                    ng-show="results.length > 0">
+              <span class="glyphicon glyphicon-download"></span>
+              Download these results
+            </button>
+          </div>
         </form>
       </div>
       <br />

--- a/opal/core/search/templates/extract.html
+++ b/opal/core/search/templates/extract.html
@@ -75,10 +75,9 @@
                              ng-model="query.query"
                              ng-show="isText(query.column, query.field) && query.field != null"
                              ng-options="x for x in query.lookup_list"
-                             data-trigger="focus" bs-tooltip="tooltip"
-                             data-placement="top" data-title="4. Add your value"
-                             set-focus-if="isText(query.column, query.field) && query.field != null  && query.queryType != null"
                              bs-typeahead
+                             placeholder="4. Add your value"
+                             set-focus-if="isText(query.column, query.field) && query.field != null  && query.queryType != null"
                              />
                     <input type="text" ng-model="query.query"
                              class="form-control content-offset-below-10"

--- a/opal/core/search/templates/extract.html
+++ b/opal/core/search/templates/extract.html
@@ -46,7 +46,10 @@
                     <span ng-if="query.column != 'tagging'">
                       <select class="form-control content-offset-below-10"
                               ng-if="query.field != null && !isDate(query.column, query.field)"
-                              ng-model="query.queryType" >
+                              ng-model="query.queryType" data-trigger="focus" bs-tooltip="tooltip"
+                              data-placement="top" data-title="3. Select your query type"
+                              set-focus-if="query.field != null && !isDate(query.column, query.field)"
+                              >
                         <option>Equals</option>
                         <option ng-show="isText(query.column, query.field)">Contains</option>
                       </select>
@@ -74,7 +77,7 @@
                              ng-options="x for x in query.lookup_list"
                              data-trigger="focus" bs-tooltip="tooltip"
                              data-placement="top" data-title="4. Add your value"
-                             set-focus-if="isText(query.column, query.field) && query.field != null"
+                             set-focus-if="isText(query.column, query.field) && query.field != null  && query.queryType != null"
                              bs-typeahead
                              />
                     <input type="text" ng-model="query.query"
@@ -104,7 +107,7 @@
                   </div>
                 </div>
               </span>
-              <div class="content-offset-20 ">
+              <div class="content-offset-20 content-offset-below-10">
                 <a class="btn btn-danger" ng-show="criteria.length > 1" ng-click="removeCriteria()">
                    Clear search
                  </a>

--- a/opal/core/search/templates/extract.html
+++ b/opal/core/search/templates/extract.html
@@ -43,9 +43,9 @@
                         <option ng-repeat="field in searchableFields(col)">[[field]]</option>
                       </select>
                     </span>
-                    <span ng-if="query.column != 'tagging'">
+                    <span ng-show="query.column != 'tagging'">
                       <select class="form-control content-offset-below-10"
-                              ng-if="query.field != null && !isDate(query.column, query.field)"
+                              ng-show="query.field != null && !isDate(query.column, query.field)"
                               ng-model="query.queryType" data-trigger="focus" bs-tooltip="tooltip"
                               data-placement="top" data-title="3. Select your query type"
                               set-focus-if="query.field != null && !isDate(query.column, query.field)"
@@ -54,7 +54,7 @@
                         <option ng-show="isText(query.column, query.field)">Contains</option>
                       </select>
                       <select class="form-control content-offset-below-10"
-                                ng-if="query.field != null && isDate(query.column, query.field)"
+                                ng-show="query.field != null && isDate(query.column, query.field)"
                               ng-model="query.queryType" data-trigger="focus" bs-tooltip="tooltip"
                               data-placement="top" data-title="3. Select your query type"
                               set-focus-if="query.field != null && isDate(query.column, query.field)" >
@@ -62,7 +62,7 @@
                         <option>After</option>
                       </select>
                       <select class="form-control content-offset-below-10" ng-model="query.query"
-                              ng-if="isBoolean(query.column, query.field) && query.field != null"
+                              ng-show="isBoolean(query.column, query.field) && query.field != null"
                               data-trigger="focus" bs-tooltip="tooltip"
                               data-placement="top" data-title="3. Select your query type"
                               set-focus-if="isBoolean(query.column, query.field) && query.field != null"
@@ -71,9 +71,9 @@
                         <option>false</option>
                       </select>
                       <input type="text"
-                             class="form-control content-offset-below-10"
+                             class="form-control onions content-offset-below-10"
                              ng-model="query.query"
-                             ng-if="isText(query.column, query.field) && query.field != null"
+                             ng-show="isText(query.column, query.field) && query.field != null"
                              ng-options="x for x in query.lookup_list"
                              data-trigger="focus" bs-tooltip="tooltip"
                              data-placement="top" data-title="4. Add your value"
@@ -82,7 +82,7 @@
                              />
                     <input type="text" ng-model="query.query"
                              class="form-control content-offset-below-10"
-                             ng-if="isDate(query.column, query.field) && query.field != null"
+                             ng-show="isDate(query.column, query.field) && query.field != null"
                              data-trigger="focus" bs-tooltip="tooltip"
                              data-placement="top" data-title="4. Add your value"
             	               ng-pattern="/^(0?[1-9]|[12][0-9]|3[01])\/(0?[1-9]|1[012])\/(\d{4})$/"

--- a/opal/static/css/opal.css
+++ b/opal/static/css/opal.css
@@ -315,10 +315,6 @@ input.ng-invalid.ng-dirty { background-color : #fcc; }
 
 .dropdown-menu { z-index: 1060; }
 
-
-
-
-
 .timeline {
   position: relative;
   padding-bottom: 1px;

--- a/opal/static/css/opal.css
+++ b/opal/static/css/opal.css
@@ -35,7 +35,18 @@ h1.larger { font-size: 52px; }
 }
 .content-offset { margin-top: 50px; }
 .content-offset-25 { margin-top: 25px; }
-.content-offset-below-25 { margin-bottom: 25px; }
+.content-offset-20{
+    margin-top: 20px;
+}
+.content-offset-below-20 {
+    margin-bottom: 20px;
+}
+.content-offset-10{
+    margin-top: 10px;
+}
+.content-offset-below-10 {
+    margin-bottom: 10px;
+}
 .content-offset-75 {margin-top: 75px; }
 .content-centered { padding-top: 20%; height: 100%; }
 .heading { position: fixed; top: 50px; width: 100%; z-index: 3; }
@@ -389,4 +400,13 @@ input.ng-invalid.ng-dirty { background-color : #fcc; }
   content: "";
   display: block;
   position: absolute;
+}
+
+.saved-search:hover{
+  color: #333;
+}
+
+.saved-search{
+  font-size: 30px;
+  margin-right: 10px;
 }

--- a/opal/static/js/opal/controllers_module.js
+++ b/opal/static/js/opal/controllers_module.js
@@ -15,7 +15,7 @@ var controllers = OPAL.module('opal.controllers', [
 
 controllers.controller('RootCtrl', function($scope, $location) {
     $scope.$location = $location;
-    
+
 	$scope.keydown = function(e) {
 		$scope.$broadcast('keydown', e);
 	};

--- a/opal/static/js/opal/directives.js
+++ b/opal/static/js/opal/directives.js
@@ -35,7 +35,6 @@ directives.directive('placeholder', function($timeout){
 
 directives.directive('markdown', function () {
 	return function postLink (scope, element, attrs) {
-
 	    var prefix = 'item';
 	    if( _.isUndefined(scope['item']) ){
 		if(! _.isUndefined(scope['editing']) )
@@ -58,15 +57,23 @@ directives.directive('markdown', function () {
 	}
 });
 
-directives.directive('focusOnThis', function($timeout){
-    return {
-        link: function(scope, elem, attr){
-            $timeout(function(){
-                elem[0].focus();
-            });
+directives.directive('setFocusIf', function($timeout) {
+  return {
+    link: function($scope, $element, $attr) {
+      $scope.$watch($attr.setFocusIf, function(value) {
+        if ( value ) {
+          $timeout(function() {
+            // We must reevaluate the value in case it was changed by a subsequent
+            // watch handler in the digest.
+            if ( $scope.$eval($attr.setFocusIf) ) {
+              $element[0].focus();
+            }
+          }, 0, false);
         }
+      });
     }
-});
+  }
+});;
 
 angular.module('ui.bootstrap.modal').directive('modalWindow', function ($timeout) {
   return {

--- a/opal/static/js/ui-bootstrap-tpls-0.11.0.js
+++ b/opal/static/js/ui-bootstrap-tpls-0.11.0.js
@@ -2546,7 +2546,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
               // Set the initial positioning.
               tooltip.css({ top: 0, left: 0, display: 'block' });
 
-              // Now we add it to the DOM because need some info about it. But it's not 
+              // Now we add it to the DOM because need some info about it. But it's not
               // visible yet anyway.
               if ( appendToBody ) {
                   $document.find( 'body' ).append( tooltip );
@@ -2574,7 +2574,7 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
               $timeout.cancel( popupTimeout );
               popupTimeout = null;
 
-              // And now we remove it from the DOM. However, if we have animation, we 
+              // And now we remove it from the DOM. However, if we have animation, we
               // need to wait for it to expire beforehand.
               // FIXME: this is a placeholder for a port of the transitions library.
               if ( scope.tt_animation ) {
@@ -2688,9 +2688,10 @@ angular.module( 'ui.bootstrap.tooltip', [ 'ui.bootstrap.position', 'ui.bootstrap
   };
 })
 
-.directive( 'tooltip', [ '$tooltip', function ( $tooltip ) {
-  return $tooltip( 'tooltip', 'tooltip', 'mouseenter' );
-}])
+// removing this to stop conflict with angular strap
+// .directive( 'tooltip', [ '$tooltip', function ( $tooltip ) {
+//   return $tooltip( 'tooltip', 'tooltip', 'mouseenter' );
+// }])
 
 .directive( 'tooltipHtmlUnsafePopup', function () {
   return {
@@ -3591,7 +3592,7 @@ angular.module('ui.bootstrap.typeahead', ['ui.bootstrap.position', 'ui.bootstrap
       //we need to propagate user's query so we can higlight matches
       scope.query = undefined;
 
-      //Declare the timeout promise var outside the function scope so that stacked calls can be cancelled later 
+      //Declare the timeout promise var outside the function scope so that stacked calls can be cancelled later
       var timeoutPromise;
 
       //plug into $parsers pipeline to open a typeahead on view changes initiated from DOM


### PR DESCRIPTION
fixed the spacing so that we don't overlap.
we now use bootstrap tooltips and a new focus directive to drive the user through the flow.
saved searches are encapsulated on the right.
fixed the bug @GabPoll found

What's not fixed is some of the saved search naming stuff which should probably be part of a separate ticket.
