### PR TITLE
Fix startplugin command to handle opal-names.

### DIFF
--- a/bin/opal
+++ b/bin/opal
@@ -192,6 +192,7 @@ def startplugin(args):
 
     if 'opal' in name:
         reponame = name
+        name = name.replace('opal-', '')
     else:
         reponame = 'opal-{0}'.format(name)
 


### PR DESCRIPTION
Without this, startplugin opal-something will create a broken plugin
because it *really* expects startplugin something.  This just strips
opal- from the name if it is present, because the naming of other
existing plugins suggests this is what you should do.