### PR TITLE
bunch queries for content types

### DIFF
--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -8,9 +8,10 @@ from django.views.generic import View
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import routers, status, viewsets
 from rest_framework.response import Response
-from opal.models import Episode
+from opal.models import Episode, Synonym, Team, Macro
 from opal.core import application, exceptions, plugins
 from opal.core import glossolalia
+from opal.core.lookuplists import LookupList
 from opal.utils import stringport, camelcase_to_underscore
 from opal.core import schemas
 from opal.core.subrecords import subrecords
@@ -114,14 +115,12 @@ class OptionsViewSet(viewsets.ViewSet):
     base_name = 'options'
 
     def list(self, request):
-        from opal.core.lookuplists import LookupList
-        from opal.models import Synonym, Team, Macro
+
 
         data = {}
         subclasses = LookupList.__subclasses__()
         for model in subclasses:
             options = list(model.objects.all().values_list("name", flat=True))
-            options = [instance.name for instance in model.objects.all()]
             data[model.__name__.lower()] = options
 
         model_to_ct = ContentType.objects.get_for_models(

--- a/opal/tests/models.py
+++ b/opal/tests/models.py
@@ -8,7 +8,6 @@ from opal import models
 from opal.core import lookuplists
 
 
-
 class Hat(lookuplists.LookupList):
     pass
 
@@ -16,6 +15,15 @@ class Hat(lookuplists.LookupList):
 class HatWearer(models.EpisodeSubrecord):
     name = dmodels.CharField(max_length=200)
     hats = dmodels.ManyToManyField(Hat, related_name="hat_wearers")
+
+
+class Dog(lookuplists.LookupList):
+    pass
+
+
+class DogOwner(models.EpisodeSubrecord):
+    name = dmodels.CharField(max_length=200)
+    dog = fields.ForeignKeyOrFreeText(Dog)
 
 
 class Colour(models.EpisodeSubrecord):

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -54,6 +54,30 @@ class ExtractSchemaTestCase(TestCase):
         self.assertEqual([{}], api.ExtractSchemaViewSet().list(None).data)
 
 
+class OptionTestCase(TestCase):
+    def setUp(self):
+        self.top = Hat.objects.create(name="top")
+        self.bowler = Hat.objects.create(name="bowler")
+        self.synonym_name = "high"
+        self.user = User.objects.create(username='testuser')
+        content_type = ContentType.objects.get_for_model(Hat)
+        models.Synonym.objects.get_or_create(
+            content_type=content_type,
+            object_id=self.top.id,
+            name=self.synonym_name
+        )
+        self.viewset = api.OptionsViewSet
+
+    def test_options_loader(self):
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        response = self.viewset().list(mock_request)
+        result = response.data
+        self.assertIn("hat", result)
+        self.assertEqual(set(result["hat"]), {"top", "bowler", "high"})
+        self.assertEqual(response.status_code, 200)
+
+
 class SubrecordTestCase(TestCase):
 
     def setUp(self):

--- a/opal/tests/test_utils_fields.py
+++ b/opal/tests/test_utils_fields.py
@@ -1,26 +1,20 @@
 """
 Test util fields
 """
-from django.db import models
 from django.test import TestCase
+from opal.tests.models import DogOwner, Dog
 
-from opal.core.fields import ForeignKeyOrFreeText
-from opal.core import lookuplists
 
 class FKorFTTest(TestCase):
     def setUp(self):
-        class LookupList(lookuplists.LookupList): pass
-        
-        class Model(models.Model):
-            field = ForeignKeyOrFreeText(LookupList)
-            
-        self.Model = Model
-        self.ll = LookupList
-        
+        self.Model = DogOwner
+        self.ll = Dog
+
     def test_set_none(self):
         # As much as anything this is checking that we *can* set None
         # on a FKorFT field - ensuring a previous bug where .split()
         # was always called on the value does not reappear.
         instance = self.Model()
-        instance.field = None
-        self.assertEqual('', instance.field)
+        instance.dog = None
+
+        self.assertEqual('', instance.dog)


### PR DESCRIPTION
local speed up

old
super GET /api/v0.1/options/ 200 (1.99 seconds) (365 SQL queries, 1869.0 ms)

new
super GET /api/v0.1/options/ 200 (1.13 seconds) (214 SQL queries, 1489.0 ms)