### PR TITLE
Improve load speed fix url changing

### DIFF
--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -376,14 +376,13 @@ class PatientViewSet(viewsets.ViewSet):
 
     def list(self, request):
         from opal.models import Patient
-
-        return Response([p.to_dict(request.user) for p in Patient.objects.all()])
+        results = [p.to_dict(request.user) for p in Patient.objects.all()]
+        return _build_json_response(results)
 
     def retrieve(self, request, pk=None):
         from opal.models import Patient
-
         patient = Patient.objects.get(pk=pk)
-        return Response(patient.to_dict(request.user))
+        return _build_json_response(patient.to_dict(request.user))
 
 
 router.register('patient', PatientViewSet)

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -8,7 +8,7 @@ from django.views.generic import View
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import routers, status, viewsets
 from rest_framework.response import Response
-from opal.models import Episode, Synonym, Team, Macro
+from opal.models import Episode, Synonym, Team, Macro, Patient
 from opal.core import application, exceptions, plugins
 from opal.core import glossolalia
 from opal.core.lookuplists import LookupList
@@ -338,8 +338,6 @@ class EpisodeViewSet(viewsets.ViewSet):
         * Inform glossolalia
         * return the patient
         """
-        from opal.models import Patient
-
         demographics_data = request.data.pop('demographics', None)
         location_data     = request.data.pop('location', {})
         tagging           = request.data.pop('tagging', {})
@@ -375,7 +373,6 @@ class PatientViewSet(viewsets.ViewSet):
     base_name = 'patient'
 
     def retrieve(self, request, pk=None):
-        from opal.models import Patient
         patient = Patient.objects.get(pk=pk)
         return _build_json_response(patient.to_dict(request.user))
 

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -374,11 +374,6 @@ class EpisodeViewSet(viewsets.ViewSet):
 class PatientViewSet(viewsets.ViewSet):
     base_name = 'patient'
 
-    def list(self, request):
-        from opal.models import Patient
-        results = [p.to_dict(request.user) for p in Patient.objects.all()]
-        return _build_json_response(results)
-
     def retrieve(self, request, pk=None):
         from opal.models import Patient
         patient = Patient.objects.get(pk=pk)

--- a/opal/static/js/opal/controllers/episode_list.js
+++ b/opal/static/js/opal/controllers/episode_list.js
@@ -41,6 +41,7 @@ angular.module('opal.controllers').controller(
 
                 var target = $scope.path_base + $scope.currentTag + '/' + subtag;
                 $location.path(target);
+                $location.replace();
                 return;
             }
         }
@@ -81,7 +82,6 @@ angular.module('opal.controllers').controller(
             if(_.contains(_.keys(options.tag_hierarchy), tag)){
                 $location.path($scope.path_base + tag)
             }else{
-
                 for(var prop in options.tag_hierarchy){
                     if(options.tag_hierarchy.hasOwnProperty(prop)){
                         if(_.contains(_.values(options.tag_hierarchy[prop]), tag)){

--- a/opal/static/js/opal/controllers/episode_list_redirect.js
+++ b/opal/static/js/opal/controllers/episode_list_redirect.js
@@ -14,4 +14,5 @@ angular.module('opal.controllers').controller(
             }
         }
         $location.path(path_base + tag + "/" + subtag);
+        $location.replace();
 });

--- a/opal/static/js/opal/services/patient_loader.js
+++ b/opal/static/js/opal/services/patient_loader.js
@@ -1,19 +1,19 @@
 angular.module('opal.services')
     .factory('patientLoader', function($q, $window, $http, $route, Episode, recordLoader ) {
         return function() {
+          "use strict";
 	        var deferred = $q.defer();
-            recordLoader.then(function(records){
-                var patient_id = $route.current.params.patient_id;
+            var patient_id = $route.current.params.patient_id;
+            if(!patient_id){
+                deferred.resolve([]);
+            }
+            var target = "/api/v0.1/patient/" + patient_id + '/';
+            var getEpisodePromise = $http.get(target);
 
-                if(!patient_id){
-                    deferred.resolve([]);
-                }
 
-                target = "/api/v0.1/patient/" + patient_id + '/';
-
-                $http.get(target).then(
-                    function(resources) {
-                        var patient = resources.data;
+            $q.all([recordLoader, getEpisodePromise]).then(
+                    function(results)   {
+                        var patient = results[1].data;
                         patient.episodes = _.map(patient.episodes, function(resource) {
                             return new Episode(resource);
                         });
@@ -21,8 +21,7 @@ angular.module('opal.services')
                     }, function() {
                         // handle error better
                         $window.alert('Episodes could not be loaded');
-                    });
-            });
+              });
 	        return deferred.promise;
         };
     });

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -13,6 +13,7 @@ from mock import patch, MagicMock
 from opal import models
 from opal.tests.models import Colour, PatientColour, HatWearer, Hat
 from opal.core.test import OpalTestCase
+from opal.core.views import _build_json_response
 
 # this is used just to import the class for EpisodeListApiTestCase
 from opal.tests.test_patient_lists import TaggingTestPatientList # flake8: noqa
@@ -498,8 +499,9 @@ class EpisodeTestCase(TestCase):
             parent=self.micro)
 
     def test_retrieve_episode(self):
-        response = api.EpisodeViewSet().retrieve(self.mock_request, pk=self.episode.pk)
-        self.assertEqual(self.episode.to_dict(self.user), response.data)
+        response = api.EpisodeViewSet().retrieve(self.mock_request, pk=self.episode.pk).data
+        expected = json.loads(_build_json_response(self.episode.to_dict(self.user)).content)
+        self.assertEqual(expected, response)
 
     def test_retrieve_nonexistent_episode(self):
         response = api.EpisodeViewSet().retrieve(self.mock_request, pk=678687)
@@ -662,5 +664,6 @@ class PatientTestCase(TestCase):
         self.mock_request = MagicMock(name='request')
 
     def test_retrieve_episode(self):
-        response = api.PatientViewSet().retrieve(self.mock_request, pk=self.patient.pk)
-        self.assertEqual(self.patient.to_dict(None), response.data)
+        response = api.PatientViewSet().retrieve(self.mock_request, pk=self.patient.pk).content
+        expected = _build_json_response(self.patient.to_dict(None)).content
+        self.assertEqual(expected, response)


### PR DESCRIPTION
sorry bit a of a random hodgepodge of features.

1) use location.replace in list views so we don't break the back button
2) load schema and episode at the same time in the episode detail view saves us 0.25 seconds on each load
3) patient view needs to return the serialised response so we can use the new date logic