### PR TITLE
Tagless Visibility

### DIFF
--- a/opal/static/js/opal/routes.js
+++ b/opal/static/js/opal/routes.js
@@ -15,9 +15,6 @@ app.config(
 				     episodes: function(episodesLoader) { return episodesLoader(); },
 				     options: function(Options) { return Options; },
                      profile: function(UserProfile){ return UserProfile; },
-                     episodeVisibility: function(episodeVisibility){
-                         return episodeVisibility;
-                     }
 			     },
 			     templateUrl: function(params){
                      var target =  '/templates/episode_list.html';

--- a/opal/static/js/opal/services/episode_visibility.js
+++ b/opal/static/js/opal/services/episode_visibility.js
@@ -1,3 +1,19 @@
+//
+// This service allows us to dynamically filter visible episodes.
+// (This is particularly useful in e.g. a patient list with many patients)
+//
+// In the current implementation there are a small number of allowed filters
+//
+// * Name
+// * Hospital Number
+// * Ward
+// * Bed
+//
+// TODO: At some point in the future we might like to refactor this to be
+// significantly more generic, or indeed consider whether it makes any real
+// sense to have this fuctionality in it's own service rather than in the
+// Patient List controller.
+//
 angular.module('opal.services')
     .factory('episodeVisibility', function(){
     return function(episode, $scope) {
@@ -8,24 +24,6 @@ angular.module('opal.services')
         var name = $scope.query.name;
         var ward = $scope.query.ward;
         var bed = $scope.query.bed;
-
-        // Not active (no tags) - hide it.
-        if(!episode.active && $scope.currentTag != 'mine'){
-            return false;
-        }
-
-        // Not in the top level tag - hide it
-	    if (_.keys(episode.tagging[0]).indexOf($scope.currentTag) == -1 ||
-            !episode.tagging[0][$scope.currentTag]) {
-		    return false;
-	    }
-
-        // Not in the current subtag
-	    if ($scope.currentSubTag != 'all' &&
-            (_.keys(episode.tagging[0]).indexOf($scope.currentSubTag) == -1 ||
-             !episode.tagging[0][$scope.currentSubTag])){
-		    return false;
-	    }
 
         // filtered out by hospital number
         if (demographics.hospital_number &&

--- a/opal/static/js/opaltest/servicesTest.js
+++ b/opal/static/js/opaltest/servicesTest.js
@@ -291,47 +291,52 @@ describe('services', function() {
         it('should allow inactive episodes on mine', function(){
             episode.active = false;
             $scope.currentTag = 'mine';
-            expect(episodeVisibility(episode, $scope, false)).toBe(true);
+            expect(episodeVisibility(episode, $scope)).toBe(true);
         });
-        it('should reject inactive episodes', function(){
+        it('should allow inactive episodes', function(){
             episode.active = false;
-            expect(episodeVisibility(episode, $scope, false)).toBe(false);
-        });
-        it('should reject if the current tag is not true', function(){
-            expect(episodeVisibility(episode, $scope, false)).toBe(false);
-        });
-        it('should reject if the current subtag is not true', function(){
-            $scope.currentTag = 'tropical';
-            $scope.currentSubTag = 'tropical_outpatients';
-            expect(episodeVisibility(episode, $scope, false)).toBe(false);
+            expect(episodeVisibility(episode, $scope)).toBe(true);
         });
         it('should reject if the hospital number filter fails', function(){
             $scope.currentTag = 'tropical';
             $scope.query.hospital_number = '123'
-            expect(episodeVisibility(episode, $scope, false)).toBe(false);
+            expect(episodeVisibility(episode, $scope)).toBe(false);
         });
         it('should allow if the hospital number filter passes', function(){
             $scope.currentTag = 'tropical';
-            expect(episodeVisibility(episode, $scope, false)).toBe(true);
+            expect(episodeVisibility(episode, $scope)).toBe(true);
         });
         it('should reject if the name filter fails', function(){
             $scope.currentTag = 'tropical';
             $scope.query.name = 'Fake Name';
-            expect(episodeVisibility(episode, $scope, false)).toBe(false);
+            expect(episodeVisibility(episode, $scope)).toBe(false);
         });
         it('should allow if the name filter passes', function(){
             $scope.currentTag = 'tropical';
             $scope.query.name = 'john'
-            expect(episodeVisibility(episode, $scope, false)).toBe(true);
+            expect(episodeVisibility(episode, $scope)).toBe(true);
         });
-        it('should allow if in the tag & unfiltered', function(){
-            $scope.currentTag = 'tropical';
-            expect(episodeVisibility(episode, $scope, false)).toBe(true);
-        })
+        it('should allow if unfiltered', function(){
+            expect(episodeVisibility(episode, $scope)).toBe(true);
+        });
+        it('should allow if the bed filter passes', function(){
+            $scope.query.bed = '15'
+            expect(episodeVisibility(episode, $scope)).toBe(true);
+        });
+        it('should allow if the bed rangefilter passes', function(){
+            $scope.query.bed = '10-20'
+            expect(episodeVisibility(episode, $scope)).toBe(true);
+        });
+        it('should fail if the bed filter fails', function(){
+            $scope.query.bed = '14'
+            expect(episodeVisibility(episode, $scope)).toBe(false);
+        });
+        it('should fail if the bed range filter fails', function(){
+            $scope.query.bed = '1-10'
+            expect(episodeVisibility(episode, $scope)).toBe(false);
+        });
+
     });
-
-
-
 
     describe('episodesLoader', function() {
         var episodesLoader, $httpBackend, listSchemaLoader, $route;


### PR DESCRIPTION
These days ensuring that episodes in a patient list controller are appropriately tagged is handled on the server side via URLS.

Additionally, there is no longer a third parameter to the visibility check, we should really test the bed range filter, and now that episodeVisibility isn't pluggable, there's no reason to provide it to the resolver.

This change also un-locks the ability to have Patient Lists based on criteria other than tag.
