### PR TITLE
Make PatientList a core.discoverable.DiscoverableFeature

### DIFF
--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -436,5 +436,8 @@ class EpisodeListApi(View):
     """
     def get(self, *args, **kwargs):
         # while we manage transition lets allow a fall back to the old way
-        patient_list = PatientList.get_class(self.request, **kwargs)
-        return _build_json_response(patient_list.get_serialised())
+        name = kwargs['tag']
+        if 'subtag' in kwargs:
+            name += '-' + kwargs['subtag']
+        patient_list = PatientList.get(name)()
+        return _build_json_response(patient_list.to_dict(self.request.user))

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -14,11 +14,11 @@ class PatientList(discoverable.DiscoverableFeature):
 
     @property
     def schema(self):
-        raise "this needs to be implemented"
+        raise ValueError("this needs to be implemented")
 
     @property
     def queryset(self):
-        raise "this needs to be implemented"
+        raise ValueError("this needs to be implemented")
 
     def get_queryset(self):
         return self.queryset

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -1,14 +1,16 @@
+"""
+This module defines the base PatientList classes.
+"""
 from opal.models import Episode
-from opal.core import app_importer
+from opal.core import discoverable
 
 
-class PatientList(object):
+class PatientList(discoverable.DiscoverableFeature):
     """
     A view of a list shown on the list page, complete with schema that
     define the columns shown and a queryset that defines the episodes shown
     """
-    def __init__(self, request, *args, **kwargs):
-        self.request = request
+    module_name = 'patient_lists'
 
     @property
     def schema(self):
@@ -21,21 +23,9 @@ class PatientList(object):
     def get_queryset(self):
         return self.queryset
 
-    def get_serialised(self):
+    def to_dict(self, user):
         # only bringing in active seems a sensible default at this time
-        return self.get_queryset().serialised_active(self.request.user)
-
-    @classmethod
-    def list_classes(klass):
-        return app_importer.get_subclass("patient_lists", klass)
-
-    @classmethod
-    def get_class(klass, request, **kwargs):
-        list_classes = klass.list_classes()
-        for list_class in list_classes:
-            lc = list_class.get(**kwargs)
-            if lc:
-                return lc(request)
+        return self.get_queryset().serialised_active(user)
 
 
 class TaggedPatientList(PatientList):
@@ -47,14 +37,14 @@ class TaggedPatientList(PatientList):
     tag = "Implement me please"
 
     @classmethod
-    def get(klass, **kwargs):
-        tag = kwargs.get("tag", None)
-        subtag = kwargs.get("subtag", None)
-        klass_subtag = getattr(klass, "subtag", None)
-
-        if tag and klass.tag == tag.lower():
-            if not klass_subtag or klass_subtag == subtag.lower():
-                return klass
+    def slug(klass):
+        """
+        For a tagged patient list, the slug is made up of the tags.
+        """
+        s = klass.tag
+        if hasattr(klass, 'subtag'):
+            s += '-' + klass.subtag
+        return s
 
     def get_queryset(self):
         filter_kwargs = dict(tagging__archived=False)

--- a/opal/static/js/opal/routes.js
+++ b/opal/static/js/opal/routes.js
@@ -21,7 +21,7 @@ app.config(
                      if(params.tag){
                          target += '/' + params.tag;
                          if(params.subtag){
-                             target += '/' + params.subtag;
+                             target += '-' + params.subtag;
                          }
                      }
                      return target;

--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -1,4 +1,7 @@
-from mock import MagicMock
+"""
+Unittests for opal.core.patient_lists
+"""
+from mock import MagicMock, PropertyMock, patch
 from opal.core.patient_lists import PatientList, TaggedPatientList
 from opal.tests import models
 from opal.models import Patient, Team
@@ -20,8 +23,24 @@ class TaggingTestNotSubTag(TaggedPatientList):
         models.Demographics,
     ]
 
-
 class TestPatientList(OpalTestCase):
+
+    def test_unimplemented_schema(self):
+        with self.assertRaises(ValueError):
+            schema = PatientList().schema
+
+    def test_unimplemented_queryset(self):
+        with self.assertRaises(ValueError):
+            queryset = PatientList().queryset
+
+    def test_get_queryset_default(self):
+        mock_queryset = MagicMock('Mock Queryset')
+        with patch.object(PatientList, 'queryset', new_callable=PropertyMock) as queryset:
+            queryset.return_value = mock_queryset
+            self.assertEqual(mock_queryset, PatientList().get_queryset())
+
+
+class TestTaggedPatientList(OpalTestCase):
     def setUp(self):
         self.patient = Patient.objects.create()
         self.episode_1 = self.patient.create_episode()

--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -34,16 +34,12 @@ class TestPatientList(OpalTestCase):
         eater = Team.objects.create(name="eater")
         Team.objects.create(name="herbivore", parent=eater)
         self.episode_2.set_tag_names(["eater", "herbivore"], self.user)
-        mock_request = MagicMock(name='Mock request')
-        mock_request.user = self.user
 
-        patient_list = PatientList.get_class(
-            mock_request, tag="eater", subtag="herbivore"
-        )
+        patient_list = PatientList.get('eater-herbivore')()
         self.assertEqual(
             [self.episode_2], [i for i in patient_list.get_queryset()]
         )
-        serialized = patient_list.get_serialised()
+        serialized = patient_list.to_dict(self.user)
         self.assertEqual(len(serialized), 1)
         self.assertEqual(serialized[0]["id"], 2)
 
@@ -53,15 +49,11 @@ class TestPatientList(OpalTestCase):
         '''
         Team.objects.create(name="carnivore")
         self.episode_2.set_tag_names(["carnivore"], self.user)
-        mock_request = MagicMock(name='Mock request')
-        mock_request.user = self.user
 
-        patient_list = PatientList.get_class(
-            mock_request, tag="carnivore"
-        )
+        patient_list = PatientList.get("carnivore")()
         self.assertEqual(
             [self.episode_2], [i for i in patient_list.get_queryset()]
         )
-        serialized = patient_list.get_serialised()
+        serialized = patient_list.to_dict(self.user)
         self.assertEqual(len(serialized), 1)
         self.assertEqual(serialized[0]["id"], 2)

--- a/opal/views.py
+++ b/opal/views.py
@@ -42,7 +42,10 @@ class EpisodeListTemplateView(TemplateView):
         # the list redirect view, so if there are no kwargs, just
         # return an empty context
         if kwargs:
-            patient_list = PatientList.get_class(self.request, **kwargs)
+            name = kwargs['tag']
+            if 'subtag' in kwargs:
+                name += '-' + kwargs['subtag']
+            patient_list = PatientList.get(name)
             return _get_column_context(patient_list.schema, **kwargs)
         else:
             return []


### PR DESCRIPTION
Convert our declarative PatientList framework to use the new OPAL discoverable helpers.
Update the calling API to use the (currently) standard .get() and .list() methods.

Note:

This PR unblocks fetching lists via slugs.