### PR TITLE
418 patientlist

### DIFF
--- a/opal/static/js/opal/controllers/episode_list_redirect.js
+++ b/opal/static/js/opal/controllers/episode_list_redirect.js
@@ -3,16 +3,18 @@ angular.module('opal.controllers').controller(
         "use strict";
         // a simple controller that redirects to the correct tag/subtag
         $scope.ready = false;
-        var tag =  $cookieStore.get('opal.currentTag') || _.keys(options.tag_hierarchy)[0];
-        var subtag =  $cookieStore.get('opal.currentSubTag') || "";
-        var path_base = '/list/';
 
-        if(!subtag){
-            if(tag in options.tag_hierarchy &&
-                options.tag_hierarchy[tag].length > 0){
-                subtag = options.tag_hierarchy[tag][0];
+        var path_base = '/list/';
+        var last_list = $cookieStore.get('opal.lastPatientList');
+        if(last_list){
+            var target = path_base + last_list;
+        }else{
+            var target = _.keys(options.tag_hierarchy)[0];
+            if(options.tag_hierarchy[target].length > 0){
+                target += '-' + options.tag_hierarchy[target][0];
             }
+            target = path_base + target;
         }
-        $location.path(path_base + tag + "/" + subtag);
+        $location.path( target + '/');
         $location.replace();
 });

--- a/opal/static/js/opal/controllers_module.js
+++ b/opal/static/js/opal/controllers_module.js
@@ -25,6 +25,8 @@ controllers.controller('RootCtrl', function($scope, $location) {
     if(typeof collaborator != 'undefined'){ collaborator($scope) };
 });
 
+controllers.controller('404Ctrl', function($scope){});
+
 controllers.config(function($datepickerProvider) {
   angular.extend($datepickerProvider.defaults, {
       autoclose: true,

--- a/opal/static/js/opal/routes.js
+++ b/opal/static/js/opal/routes.js
@@ -3,30 +3,27 @@ var app = angular.module('opal');
 app.config(
     ['$routeProvider',
      function($routeProvider) {
-             $routeProvider.when('/list/',{
-                controller: 'EpisodeRedirectListCtrl',
-                templateUrl: '/templates/episode_list.html',
-                resolve: {
-                    options: function(Options){ return Options; }
-                }
-             }).when('/list/:tag/:subtag?', {
-			     controller: 'EpisodeListCtrl',
-			     resolve: {
-				     episodes: function(episodesLoader) { return episodesLoader(); },
-				     options: function(Options) { return Options; },
-                     profile: function(UserProfile){ return UserProfile; },
-			     },
-			     templateUrl: function(params){
-                     var target =  '/templates/episode_list.html';
-                     if(params.tag){
-                         target += '/' + params.tag;
-                         if(params.subtag){
-                             target += '-' + params.subtag;
-                         }
-                     }
-                     return target;
+         $routeProvider.when('/list/',{
+             controller: 'EpisodeRedirectListCtrl',
+             templateUrl: '/templates/episode_list.html',
+             resolve: {
+                 options: function(Options){ return Options; }
+             }
+         }).when('/list/:slug', {
+			 controller: 'EpisodeListCtrl',
+			 resolve: {
+				 episodedata: function(patientListLoader) { return patientListLoader(); },
+				 options    : function(Options) { return Options; },
+                 profile    : function(UserProfile){ return UserProfile; },
+			 },
+			 templateUrl: function(params){
+                 var target =  '/templates/episode_list.html';
+                 if(params.slug){
+                     target += '/' + params.slug;
                  }
-		     })
+                 return target;
+             }
+		 })
              .when('/patient/:patient_id/:view?', {
 			     controller: 'PatientDetailCtrl',
                  resolve: {
@@ -54,5 +51,9 @@ app.config(
                  controller: 'AccountCtrl',
                  templateUrl: '/accounts/templates/account_detail.html'
 		     })
+             .when('/404', {
+                 controller: '404Ctrl',
+                 templateUrl: '/templates/404.html'
+             })
              .otherwise({redirectTo: '/'});
      }]);

--- a/opal/static/js/opal/services/patientlist_loader.js
+++ b/opal/static/js/opal/services/patientlist_loader.js
@@ -9,7 +9,7 @@ angular.module('opal.services')
 
 	        var deferred = $q.defer();
             var params = $route.current.params;
-            var target = '/api/v0.1/patientlist/' + params.list;
+            var target = '/api/v0.1/patientlist/' + params.slug + '/';
 
             var getEpisodesPromise = $http.get(target);
 

--- a/opal/static/js/opaltest/episode_list_contoller_redirect.test.js
+++ b/opal/static/js/opaltest/episode_list_contoller_redirect.test.js
@@ -24,13 +24,9 @@ describe('EpisodeRedirectListCtrl', function() {
   it('should redirect to the cookie store tag and sub tag', function() {
       var $cookieStore = {
           get: function(someKey){
-              if(someKey === "opal.currentTag"){
-                  return "cookieTag";
+              if(someKey === 'opal.lastPatientList'){
+                  return "cookietag"
               }
-              if(someKey === "opal.currentSubTag"){
-                  return "cookieSubTag";
-              }
-
               throw "unknown argument " + someKey;
           }
       };
@@ -40,30 +36,9 @@ describe('EpisodeRedirectListCtrl', function() {
           $location: $location ,
           options: fakeOptions
       });
-      expect($location.path).toHaveBeenCalledWith("/list/cookieTag/cookieSubTag");
+      expect($location.path).toHaveBeenCalledWith("/list/cookietag/");
   });
 
-  it('should redirect to the options child tag second', function(){
-    var $cookieStore = {
-        get: function(someKey){
-            if(someKey === "opal.currentTag"){
-                return "parentTag";
-            }
-            if(someKey === "opal.currentSubTag"){
-                return "";
-            }
-
-            throw "unknown argument " + someKey;
-        }
-    };
-    $controller('EpisodeRedirectListCtrl', {
-        $scope: $scope,
-        $cookieStore: $cookieStore,
-        $location: $location ,
-        options: fakeOptions
-    });
-    expect($location.path).toHaveBeenCalledWith("/list/parentTag/childTag");
-  });
 
   it('should redirect to the first option if there is no tag', function(){
         spyOn($cookieStore, 'get').and.returnValue(undefined);
@@ -73,8 +48,9 @@ describe('EpisodeRedirectListCtrl', function() {
             $location: $location ,
             options: fakeOptions
         });
-        expect($location.path).toHaveBeenCalledWith("/list/parentTag/childTag");
-        expect($cookieStore.get).toHaveBeenCalledWith("opal.currentTag");
-        expect($cookieStore.get).toHaveBeenCalledWith("opal.currentSubTag");
-  });
+        expect($location.path).toHaveBeenCalledWith("/list/parentTag-childTag/");
+        expect($cookieStore.get).toHaveBeenCalledWith("opal.lastPatientList");
+
+    });
+
 });

--- a/opal/static/js/opaltest/patientlists.loader.service.test.js
+++ b/opal/static/js/opaltest/patientlists.loader.service.test.js
@@ -22,8 +22,8 @@ describe('PatientListLoaderTest', function(){
 
         var episodedata = {id: 1, demographics: [{patient_id: 1, name: 'Jane'}] };
 
-        $route.current = {params: {list: 'mylist'}}
-        $httpBackend.whenGET('/api/v0.1/patientlist/mylist').respond([episodedata])
+        $route.current = {params: {slug: 'mylist'}}
+        $httpBackend.whenGET('/api/v0.1/patientlist/mylist/').respond([episodedata])
         patientListLoader().then(function(r){ result = r; })
 
         $rootScope.$apply();
@@ -38,8 +38,8 @@ describe('PatientListLoaderTest', function(){
     it('should resolve an error for nonexistant lists', function(){
         var result
 
-        $route.current = {params: {list: 'mylist'}}
-        $httpBackend.whenGET('/api/v0.1/patientlist/mylist').respond(404, {error: "NOT FOUND"});
+        $route.current = {params: {slug: 'mylist'}}
+        $httpBackend.whenGET('/api/v0.1/patientlist/mylist/').respond(404, {error: "NOT FOUND"});
         patientListLoader().then(function(r){ result = r; })
 
         $rootScope.$apply();

--- a/opal/templates/404.html
+++ b/opal/templates/404.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+  <h1 class="content-offset">
+    Sorry, we couldn't find that page.
+  </h1>
+  <p>
+    Perhaps you can find what you're looking for in the menu above?
+  </p>
+{% endblock %}

--- a/opal/templates/episode_list.html
+++ b/opal/templates/episode_list.html
@@ -14,7 +14,7 @@
           {% if team.visible_in_list %}
           {% if not team.has_subteams or team.parent %}
           <li ng-hide="currentTag == '{{ team.name }}' || currentSubTag == '{{ team.name }}'">
-            <a href="#/list/{% if team.parent %}{{ team.parent.name }}/{{ team.name }}{% else %}{{ team.name }}{% endif %}">
+            <a href="#/list/{% if team.parent %}{{ team.parent.name }}-{{ team.name }}{% else %}{{ team.name }}{% endif %}">
               {% if team.parent %}
               {{ team.parent.title }} /
               {% endif %}

--- a/opal/tests/test_views.py
+++ b/opal/tests/test_views.py
@@ -35,6 +35,25 @@ class BaseViewTestCase(OpalTestCase):
         v.kwargs = kw
         return v
 
+
+class EpisodeListTemplateViewTestCase(BaseViewTestCase):
+
+    def test_episode_list_view(self):
+        url = reverse("episode_list_template_view", kwargs=dict(tag="eater", subtag="herbivore"))
+        request = self.get_request(url)
+        view = views.EpisodeListTemplateView()
+        view.request = request
+        context_data = view.get_context_data(tag="eater", subtag="herbivore")
+        column_names = [i["name"] for i in context_data["columns"]]
+        self.assertEqual(column_names, ["demographics"])
+        self.should_200(views.EpisodeListTemplateView, request)
+
+    def test_get_column_context_no_list(self):
+        view = views.EpisodeListTemplateView()
+        ctx = view.get_column_context(tag='notarealthing')
+        self.assertEqual([], ctx)
+
+
 class PatientDetailTemplateViewTestCase(BaseViewTestCase):
 
     def test_default_should_200(self):
@@ -187,15 +206,3 @@ class RawTemplateViewTestCase(BaseViewTestCase):
             views.RawTemplateView, request)
         resp = view.dispatch(request, template_name='not_a_real_template.html')
         self.assertEqual(404, resp.status_code)
-
-
-class EpisodeListTemplateViewTestCase(BaseViewTestCase):
-    def test_episode_list_view(self):
-        url = reverse("episode_list_template_view", kwargs=dict(tag="eater", subtag="herbivore"))
-        request = self.get_request(url)
-        view = views.EpisodeListTemplateView()
-        view.request = request
-        context_data = view.get_context_data(tag="eater", subtag="herbivore")
-        column_names = [i["name"] for i in context_data["columns"]]
-        self.assertEqual(column_names, ["demographics"])
-        self.should_200(views.EpisodeListTemplateView, request)

--- a/opal/urls.py
+++ b/opal/urls.py
@@ -38,7 +38,7 @@ urlpatterns = patterns(
 
     # Template vires
     url(r'^templates/episode_list.html/?$', views.EpisodeListTemplateView.as_view(), name="episode_list_template_view"),
-    url(r'^templates/episode_list.html/(?P<tag>[a-z_\-]+)/?$', views.EpisodeListTemplateView.as_view(), name="episode_list_template_view"),
+    url(r'^templates/episode_list.html/(?P<tag>[0-9a-z_\-]+)/?$', views.EpisodeListTemplateView.as_view(), name="episode_list_template_view"),
     url(r'^templates/episode_list.html/(?P<tag>[a-z_\-]+)/(?P<subtag>[a-z_\-]+)/?$', views.EpisodeListTemplateView.as_view(), name="episode_list_template_view"),
 
     url(r'^templates/patient_detail.html$',
@@ -100,5 +100,5 @@ for plugin in plugins.plugins():
 
 urlpatterns += patterns(
     '',
-    url(r'templates/(?P<template_name>[a-z_/]+.html)', views.RawTemplateView.as_view())
+    url(r'templates/(?P<template_name>[0-9a-z_/]+.html)', views.RawTemplateView.as_view())
 )

--- a/opal/views.py
+++ b/opal/views.py
@@ -45,7 +45,10 @@ class EpisodeListTemplateView(TemplateView):
             name = kwargs['tag']
             if 'subtag' in kwargs:
                 name += '-' + kwargs['subtag']
-            patient_list = PatientList.get(name)
+            try:
+                patient_list = PatientList.get(name)
+            except ValueError:
+                return []
             return _get_column_context(patient_list.schema, **kwargs)
         else:
             return []


### PR DESCRIPTION
This is the next round of the patientlist refactoring.

This refactors episodelist to kill some useless code, and take the data from the PatientList api rather than the view in opal.views.

Means that urls become e.g. /list/id-id_inpatients
