### PR TITLE
418 refactor tags options

### DIFF
--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -1,8 +1,6 @@
 """
 Public facing API views
 """
-import collections
-
 from django.conf import settings
 from django.views.generic import View
 from django.contrib.contenttypes.models import ContentType

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -173,6 +173,9 @@ class OptionsViewSet(viewsets.ViewSet):
         data['tag_display'] = tag_display
         data['tag_visible_in_list'] = tag_visible_in_list
         data['tag_direct_add'] = tag_direct_add
+
+        data['first_list_slug'] = PatientList.list()[0].slug()
+
         data['macros'] = Macro.to_dict()
 
         return Response(data)

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -138,7 +138,6 @@ class OptionsViewSet(viewsets.ViewSet):
 
         data['micro_test_defaults'] = micro_test_defaults
 
-        tag_hierarchy = collections.defaultdict(list)
         tag_visible_in_list = []
         tag_direct_add = []
         tag_display = {}
@@ -159,7 +158,6 @@ class OptionsViewSet(viewsets.ViewSet):
                         tag_direct_add.append(team.name)
 
                 subteams = [st for st in teams if st.parent == team]
-                tag_hierarchy[team.name] = [st.name for st in subteams]
                 for sub in subteams:
                     tag_display[sub.name] = sub.title
 
@@ -169,7 +167,6 @@ class OptionsViewSet(viewsets.ViewSet):
                     if sub.direct_add:
                         tag_direct_add.append(sub.name)
 
-        data['tag_hierarchy'] = tag_hierarchy
         data['tag_display'] = tag_display
         data['tag_visible_in_list'] = tag_visible_in_list
         data['tag_direct_add'] = tag_direct_add

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -116,7 +116,6 @@ class OptionsViewSet(viewsets.ViewSet):
 
     def list(self, request):
 
-
         data = {}
         subclasses = LookupList.__subclasses__()
         for model in subclasses:
@@ -145,27 +144,12 @@ class OptionsViewSet(viewsets.ViewSet):
         if request.user.is_authenticated():
             teams = Team.for_user(request.user)
             for team in teams:
-                if team.parent:
-                    continue # Will be filled in at the appropriate point!
                 tag_display[team.name] = team.title
+                if team.visible_in_list:
+                    tag_visible_in_list.append(team.name)
 
-                if not team.has_subteams:
-
-                    if team.visible_in_list:
-                        tag_visible_in_list.append(team.name)
-
-                    if team.direct_add:
-                        tag_direct_add.append(team.name)
-
-                subteams = [st for st in teams if st.parent == team]
-                for sub in subteams:
-                    tag_display[sub.name] = sub.title
-
-                    if sub.visible_in_list:
-                        tag_visible_in_list.append(sub.name)
-
-                    if sub.direct_add:
-                        tag_direct_add.append(sub.name)
+                if team.direct_add:
+                    tag_direct_add.append(team.name)
 
         data['tag_display'] = tag_display
         data['tag_visible_in_list'] = tag_visible_in_list

--- a/opal/static/js/opal/controllers/episode_list_redirect.js
+++ b/opal/static/js/opal/controllers/episode_list_redirect.js
@@ -9,11 +9,7 @@ angular.module('opal.controllers').controller(
         if(last_list){
             var target = path_base + last_list;
         }else{
-            var target = _.keys(options.tag_hierarchy)[0];
-            if(options.tag_hierarchy[target].length > 0){
-                target += '-' + options.tag_hierarchy[target][0];
-            }
-            target = path_base + target;
+            var target = path_base + options.first_list_slug;
         }
         $location.path( target + '/');
         $location.replace();

--- a/opal/static/js/opaltest/episode_list_contoller_redirect.test.js
+++ b/opal/static/js/opaltest/episode_list_contoller_redirect.test.js
@@ -3,6 +3,7 @@ describe('EpisodeRedirectListCtrl', function() {
 
   var $location, $cookieStore, $controller, $scope;
   var fakeOptions = {
+      first_list_slug: 'carnivore-eater',
       tag_hierarchy: {
           "parentTag": [
               "childTag",
@@ -21,7 +22,7 @@ describe('EpisodeRedirectListCtrl', function() {
       $scope       = $rootScope.$new();
   }));
 
-  it('should redirect to the cookie store tag and sub tag', function() {
+  it('should redirect to the cookie store list', function() {
       var $cookieStore = {
           get: function(someKey){
               if(someKey === 'opal.lastPatientList'){
@@ -40,7 +41,7 @@ describe('EpisodeRedirectListCtrl', function() {
   });
 
 
-  it('should redirect to the first option if there is no tag', function(){
+  it('should redirect to the first list slug if there is no tag', function(){
         spyOn($cookieStore, 'get').and.returnValue(undefined);
         $controller('EpisodeRedirectListCtrl', {
             $scope: $scope,
@@ -48,7 +49,7 @@ describe('EpisodeRedirectListCtrl', function() {
             $location: $location ,
             options: fakeOptions
         });
-        expect($location.path).toHaveBeenCalledWith("/list/parentTag-childTag/");
+        expect($location.path).toHaveBeenCalledWith("/list/carnivore-eater/");
         expect($cookieStore.get).toHaveBeenCalledWith("opal.lastPatientList");
 
     });

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -84,6 +84,10 @@ class OptionTestCase(TestCase):
             name=self.synonym_name
         )
         self.viewset = api.OptionsViewSet
+        models.Team.objects.get_or_create(
+            name='friendly_patients',
+            title='Friendly Patients',
+        )
 
     def test_options_loader(self):
         mock_request = MagicMock(name='mock request')
@@ -100,6 +104,27 @@ class OptionTestCase(TestCase):
         response = self.viewset().list(mock_request)
         result = response.data
         self.assertEqual('carnivore', result['first_list_slug'])
+
+    def test_tag_display(self):
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        response = self.viewset().list(mock_request)
+        result = response.data
+        self.assertEqual('Friendly Patients', result['tag_display']['friendly_patients'])
+
+    def test_tag_visible_in_list(self):
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        response = self.viewset().list(mock_request)
+        result = response.data
+        self.assertIn('friendly_patients', result['tag_visible_in_list'])
+
+    def test_tag_direct_add(self):
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        response = self.viewset().list(mock_request)
+        result = response.data
+        self.assertIn('friendly_patients', result['tag_direct_add'])
 
 
 class SubrecordTestCase(TestCase):

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -15,7 +15,8 @@ from opal.tests.models import Colour, PatientColour, HatWearer, Hat
 from opal.core.test import OpalTestCase
 from opal.core.views import _build_json_response
 
-# this is used just to import the class for EpisodeListApiTestCase
+# this is used just to import the class for
+# EpisodeListApiTestCase and OptionsViewSetTestCase
 from opal.tests.test_patient_lists import TaggingTestPatientList # flake8: noqa
 
 from opal.core import api
@@ -92,6 +93,13 @@ class OptionTestCase(TestCase):
         self.assertIn("hat", result)
         self.assertEqual(set(result["hat"]), {"top", "bowler", "high"})
         self.assertEqual(response.status_code, 200)
+
+    def test_first_list_slug(self):
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        response = self.viewset().list(mock_request)
+        result = response.data
+        self.assertEqual('carnivore', result['first_list_slug'])
 
 
 class SubrecordTestCase(TestCase):


### PR DESCRIPTION
We don't really care about the hierarchy of opal.models.Teams on the front end any more (or in fact anywhere).

Let's remove that from options.
Instead, we can use the first list in our ordered PatientList.list() and redirect to that slug if there is no list.

(Partially) fixes #418