### PR TITLE
Add opal.utils.find_template

### DIFF
--- a/opal/models.py
+++ b/opal/models.py
@@ -17,8 +17,6 @@ from django.db.models import Q
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
-from django.template import TemplateDoesNotExist
-from django.template.loader import select_template
 from django.utils import timezone
 from django.conf import settings
 import reversion

--- a/opal/models.py
+++ b/opal/models.py
@@ -25,7 +25,7 @@ import reversion
 from django.utils import dateparse
 from opal.core import application, exceptions, lookuplists, plugins
 from opal import managers
-from opal.utils import camelcase_to_underscore
+from opal.utils import camelcase_to_underscore, find_template
 from opal.core.fields import ForeignKeyOrFreeText
 from opal.core.subrecords import episode_subrecords, patient_subrecords
 
@@ -724,10 +724,7 @@ class Subrecord(UpdatesFromDictMixin, TrackedModel, models.Model):
                     0, 'records/{0}/{1}/{2}.html'.format(team,
                                                               subteam,
                                                               name))
-        try:
-            return select_template(list_display_templates).template.name
-        except TemplateDoesNotExist:
-            return None
+        return find_template(list_display_templates)
 
     @classmethod
     def get_detail_template(cls, team=None, subteam=None):
@@ -739,19 +736,12 @@ class Subrecord(UpdatesFromDictMixin, TrackedModel, models.Model):
             'records/{0}_detail.html'.format(name),
             'records/{0}.html'.format(name)
         ]
-        try:
-            return select_template(templates).template.name
-        except TemplateDoesNotExist:
-            return None
+        return find_template(templates)
 
     @classmethod
     def get_form_template(cls):
         name = camelcase_to_underscore(cls.__name__)
-        templates = ['forms/{0}_form.html'.format(name)]
-        try:
-            return select_template(templates).template.name
-        except TemplateDoesNotExist:
-            return None
+        return find_template(['forms/{0}_form.html'.format(name)])
 
     @classmethod
     def get_modal_template(cls, team=None, subteam=None):
@@ -770,10 +760,7 @@ class Subrecord(UpdatesFromDictMixin, TrackedModel, models.Model):
         if cls.get_form_template():
             templates.append("modal_base.html")
 
-        try:
-            return select_template(templates).template.name
-        except TemplateDoesNotExist:
-            return None
+        return find_template(templates)
 
     def _to_dict(self, user, fieldnames):
         """

--- a/opal/tests/test_models.py
+++ b/opal/tests/test_models.py
@@ -22,44 +22,44 @@ class PatientRecordAccessTestCase(OpalTestCase):
 
 class SubrecordTestCase(OpalTestCase):
 
-    @patch('opal.models.select_template')
-    def test_display_template(self, select):
+    @patch('opal.models.find_template')
+    def test_display_template(self, find):
         Subrecord.get_display_template()
-        select.assert_called_with(['records/subrecord.html'])
+        find.assert_called_with(['records/subrecord.html'])
 
     def test_display_template_does_not_exist(self):
         self.assertEqual(None, Subrecord.get_display_template())
 
-    @patch('opal.models.select_template')
-    def test_display_template_team(self, select):
+    @patch('opal.models.find_template')
+    def test_display_template_team(self, find):
         Subrecord.get_display_template(team='test')
-        select.assert_called_with([
+        find.assert_called_with([
             'records/test/subrecord.html',
             'records/subrecord.html',
         ])
 
-    @patch('opal.models.select_template')
-    def test_display_template_subteam(self, select):
+    @patch('opal.models.find_template')
+    def test_display_template_subteam(self, find):
         Subrecord.get_display_template(team='test',
                                        subteam='really')
-        select.assert_called_with([
+        find.assert_called_with([
             'records/test/really/subrecord.html',
             'records/test/subrecord.html',
             'records/subrecord.html'
         ])
 
-    @patch('opal.models.select_template')
-    def test_detail_template(self, select):
+    @patch('opal.models.find_template')
+    def test_detail_template(self, find):
         Subrecord.get_detail_template()
-        select.assert_called_with([
+        find.assert_called_with([
             'records/subrecord_detail.html',
             'records/subrecord.html'
         ])
 
-    @patch('opal.models.select_template')
-    def test_detail_template_team(self, select):
+    @patch('opal.models.find_template')
+    def test_detail_template_team(self, find):
         Subrecord.get_detail_template(team='test')
-        select.assert_called_with([
+        find.assert_called_with([
             'records/subrecord_detail.html',
             'records/subrecord.html'
         ])
@@ -67,34 +67,33 @@ class SubrecordTestCase(OpalTestCase):
     def test_detail_template_does_not_exist(self):
         self.assertEqual(None, Subrecord.get_detail_template())
 
-    @patch('opal.models.select_template')
-    def test_detail_template_subteam(self, select):
+    @patch('opal.models.find_template')
+    def test_detail_template_subteam(self, find):
         Subrecord.get_detail_template(team='test',
                                       subteam='really')
-        select.assert_called_with(
+        find.assert_called_with(
             ['records/subrecord_detail.html',
              'records/subrecord.html'])
 
-
-    @patch('opal.models.select_template')
-    def test_form_template(self, select):
+    @patch('opal.models.find_template')
+    def test_form_template(self, find):
         Subrecord.get_form_template()
-        select.assert_called_with(['forms/subrecord_form.html'])
+        find.assert_called_with(['forms/subrecord_form.html'])
 
     def test_get_modal_template_does_not_exist(self):
         self.assertEqual(None, Subrecord.get_modal_template())
 
-    @patch('opal.models.select_template')
+    @patch('opal.models.find_template')
     @patch('opal.models.Subrecord.get_form_template')
-    def test_modal_template_no_form_template(self, modal, select):
+    def test_modal_template_no_form_template(self, modal, find):
         modal.return_value = None
         Subrecord.get_modal_template()
-        select.assert_called_with(['modals/subrecord_modal.html'])
+        find.assert_called_with(['modals/subrecord_modal.html'])
 
-    @patch('opal.models.select_template')
-    def test_modal_template_subteam(self, select):
+    @patch('opal.models.find_template')
+    def test_modal_template_subteam(self, find):
         Subrecord.get_modal_template(team='test', subteam='really')
-        select.assert_called_with([
+        find.assert_called_with([
             'modals/test/really/subrecord_modal.html',
             'modals/test/subrecord_modal.html',
             'modals/subrecord_modal.html',

--- a/opal/tests/test_utils.py
+++ b/opal/tests/test_utils.py
@@ -1,11 +1,24 @@
 from django.test import TestCase
 from django.db.models import ForeignKey, CharField
 
-from opal.utils import stringport
+from opal import utils
 
 class StringportTestCase(TestCase):
 
     def test_import(self):
         import collections
-        self.assertEqual(collections, stringport('collections'))
+        self.assertEqual(collections, utils.stringport('collections'))
 
+
+class FindTemplateTestCase(TestCase):
+
+    def test_find_template_first_exists(self):
+        self.assertEqual('base.html',
+                         utils.find_template(['base.html', 'baser.html', 'basest.html']))
+
+    def test_find_template_one_exists(self):
+        self.assertEqual('base.html',
+                         utils.find_template(['baser.html', 'base.html', 'basest.html']))
+
+    def test_find_template_none_exists(self):
+        self.assertEqual(None, utils.find_template(['baser.html', 'basest.html']))

--- a/opal/utils/__init__.py
+++ b/opal/utils/__init__.py
@@ -5,8 +5,6 @@ import importlib
 import os
 import re
 
-from django.template import engines, TemplateDoesNotExist
-
 camelcase_to_underscore = lambda str: re.sub('(((?<=[a-z])[A-Z])|([A-Z](?![A-Z]|$)))', '_\\1', str).lower().strip('_')
 
 def stringport(module):

--- a/opal/utils/__init__.py
+++ b/opal/utils/__init__.py
@@ -2,7 +2,10 @@
 Generic OPAL utilities
 """
 import importlib
+import os
 import re
+
+from django.template import engines, TemplateDoesNotExist
 
 camelcase_to_underscore = lambda str: re.sub('(((?<=[a-z])[A-Z])|([A-Z](?![A-Z]|$)))', '_\\1', str).lower().strip('_')
 
@@ -48,3 +51,17 @@ def _itersubclasses(cls, _seen=None):
             yield sub
             for sub in _itersubclasses(sub, _seen):
                 yield sub
+
+
+def find_template(template_list):
+    """
+    Given an iterable of template paths, return the first one that
+    exists on our template path or None.
+    """
+    for path in template_list:
+        for engine in engines.all():
+            for loader in engine.engine.template_loaders:
+                for origin in loader.get_template_sources(path):
+                    if os.path.exists(origin):
+                        return path
+    return None

--- a/opal/utils/__init__.py
+++ b/opal/utils/__init__.py
@@ -5,6 +5,8 @@ import importlib
 import os
 import re
 
+from django.template import engines
+
 camelcase_to_underscore = lambda str: re.sub('(((?<=[a-z])[A-Z])|([A-Z](?![A-Z]|$)))', '_\\1', str).lower().strip('_')
 
 def stringport(module):


### PR DESCRIPTION
The repetitive try catch on TemplateDoesNotExist for successive methods is an obvious candidate for refactoring by the time that we have to do it four times on one model...

Less obvious is whether the _implementation_ of `utils.find_template` is the right one. 
This is what Django's `select_template` is doing under the hood, only without actually instantiating the `Template` (Django `Template.__init__()` parses, tokenizes etc - which is _never_ useful to us with these methods)

The risk here is that it's delving a little deeply into the only-semi-public Django API, and at some stage internal Django refactoring could just cause this to break.

I suspect it's probably fine - we have tests, and the alternative implementation (Just use select_template and catch exceptions) is clear. 

Thoughts welcome...

Fixes #467 