### PR TITLE
418 list validation

### DIFF
--- a/doc/docs/guides/list_views.md
+++ b/doc/docs/guides/list_views.md
@@ -1,39 +1,46 @@
 # OPAL Patient List views
 
-OPAL core provides support for displaying spreadsheet-style lists of patients.
+OPAL provides support for displaying lists of patients, both via a spreadsheet like view,
+and with a card based view.
 
-A list is comprised of a set of record types to display, and their ordering.
+## Defining lists
 
-### Registering a list
+OPAL patient lists are subclasses of `opal.core.patient_lists.PatientList`. Typically these
+are found in a `patient_lists.py` module of your application or plugin. (Lists _can_ be
+defined elsewhere, but may not be autodiscovered.)
 
-Your application can have a file called patient_lists.py. This defines the list views
-that the application makes available on the list page.
+A basic list needs only define it's `display_name` a `queryset` of episodes to display, and
+a `schema` of subrecords to show for each episode.
 
-We need a way to get your list patient based on the page url. Usually this will be via tag
-if you inherit from TaggedPatientList you need to define a tag and optionally a subtag.
-It should also define a queryset of episodes and a schema attribute. The schema attribute
-is the list of columns that will be displayed. The queryset is the episodes rows that
-will be displayed.
+    # patient_lists.py
+    from opal.models import Episore
+    from opal.core import patient_lists
 
-when navigated to /#/list/[[ tag ]]/[[ sub tag ]] this will look up the tag/subtag and
-return serialized episodes defined by the queryset.
+    from myapplication import models
 
-You can override get_queryset and have access to the request as self.request, to return
-a custom queryset based on GET params/user etc.
+    class AlphabetListA(patient_lists.PatientList):
+        display_name = 'A Patients'
 
-If you don't want a url like the above, patient lists are got by calling a classmethod get(\*\*url_kwargs) which returns the class.
+        queryset = Episode.objects.filter(demographics__name__istartswith='a')
 
-e.g. /#/other_list/[[ name ]]
+        schema = [
+            models.Demographics,
+            models.Location,
+            models.Diagnosis,
+            models.Treatment
+        ]
 
-could have a class method of
+The `display_name` property is the human readable name for our list - which is displayed as
+link text to our list.
 
-@classmethod
-def get(klass, url_kwargs):
-  if url_kwargs["name"] === "Larry":
-    return klass
+## Schemas
 
+Schemas are lists of Subrecords that we would like to display in our list. By default we
+render the subrecord display_template, and allow editing and addition of each subrecord in
+place.
 
 ### Template selection
+
 
 The list view is constructed by rendering a column for each record, in the order
 defined in the schema, and a row for each episode in the list.
@@ -45,3 +52,56 @@ locations:
     records/{record_name}.html
     records/{team}/{record_name}.html
     records/{team}/{subteam}/{record_name}.html
+
+## Querysets
+
+The queryset property of your list should contain all of the episodes for this particular
+list. On occasion we require a more dynamic queryset, in which case we can ovreride the
+`get_queryset` method.
+
+    # patient_lists.py
+    import datetime
+    from opal.models import Episode
+    from opal.core import patient_lists
+
+    class MyWeeklyList(patient_lists.PatientList):
+        def get_queryset(self):
+            one_week_ago = datetime.date.today() - datetime.timedelta(days=1)
+            return Episode.objects.filter(date_of_admission__gte=one_week_ago)
+
+## Ordering Lists
+
+## Slug
+
+## Templates
+
+## Tagged Patient Lists
+
+A common model for working with lists is to use lists based on the tags assigned to an episode.
+This allows users to add and remove patients from lists as they see fit, rather than attempting
+to infer it from other properties of the patient (e.g. their current location for instance.)
+which can be particularly challenging for some clinical services.
+
+OPAL provides a specific subclass for working with Tagged Patient Lists:
+
+    # patient_lists.py
+    from opal.core import patient_lists
+
+    class MyTagList(patient_lists.TaggedPatientList):
+        display_name = 'Tagged blue'
+        tag = 'blue'
+
+Tagged lists will automatically fetch the appropriate queryset for patients tagged with the tag
+you specify.
+
+### Invalid Tagged Patient Lists
+
+Tag names may not have hyphens in them - OPAL uses hyphens to distinguish between tags and subtags
+in the urls for lists, so attempting to define one will raise an exception.
+
+    class MyList(TaggedPatientList):
+        tag = 'foo-bar'
+
+    # This will raise InvalidDiscoverableFeatureError !
+
+## Access Control

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -2,7 +2,7 @@
 This module defines the base PatientList classes.
 """
 from opal.models import Episode, UserProfile
-from opal.core import discoverable
+from opal.core import discoverable, exceptions
 
 
 class PatientList(discoverable.DiscoverableFeature,
@@ -62,6 +62,17 @@ class TaggedPatientList(PatientList):
     """
     tag = "Implement me please"
     display_name = "Implement me please"
+
+    @classmethod
+    def is_valid(klass):
+        if '-' in klass.tag:
+            msg = 'Invalid tag {0}'.format(klass.tag)
+            raise exceptions.InvalidDiscoverableFeatureError(msg)
+        if hasattr(klass, 'subtag'):
+            if '-' in klass.subtag:
+                msg = 'Invalid subtag {0}'.format(klass.subtag)
+                raise exceptions.InvalidDiscoverableFeatureError(msg)
+        return True
 
     @classmethod
     def slug(klass):

--- a/opal/tests/test_core_discoverable.py
+++ b/opal/tests/test_core_discoverable.py
@@ -46,6 +46,9 @@ class BombFeature(discoverable.DiscoverableFeature):
             raise InvalidDiscoverableFeatureError('BLOWING UP')
 
 
+class Threat(BombFeature): pass
+
+
 class AppImporterTestCase(OpalTestCase):
 
     @override_settings(INSTALLED_APPS=("opal",))
@@ -64,8 +67,6 @@ class AppImporterTestCase(OpalTestCase):
 class DiscoverableFeatureTestCase(OpalTestCase):
 
     def test_is_valid_will_blow_up(self):
-
-        class Threat(BombFeature): pass
 
         # We only care that the above class did not raise an exception.
         self.assertTrue(True)
@@ -99,6 +100,9 @@ class DiscoverableFeatureTestCase(OpalTestCase):
         self.assertEqual(3, len(subs))
         for s in [BlueColour, RedColour, SeaGreenColour]:
             self.assertIn(s, subs)
+
+    def test_list_invalid_subclasses(self):
+        self.assertEqual([Threat], list(BombFeature.list()))
 
     def test_get_not_a_thing(self):
         with self.assertRaises(ValueError):

--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -4,6 +4,7 @@ Unittests for opal.core.patient_lists
 from django.contrib.auth.models import User
 from mock import MagicMock, PropertyMock, patch
 
+from opal.core import exceptions
 from opal.core.patient_lists import PatientList, TaggedPatientList
 from opal.tests import models
 from opal.models import Patient, Team, UserProfile
@@ -123,3 +124,14 @@ class TestTaggedPatientList(OpalTestCase):
     def test_list(self):
         expected = [TaggingTestNotSubTag, TaggingTestPatientList]
         self.assertEqual(expected, list(TaggedPatientList.list()))
+
+    def test_invalid_tag_name(self):
+        with self.assertRaises(exceptions.InvalidDiscoverableFeatureError):
+            class MyList(TaggedPatientList):
+                tag = 'foo-bar'
+
+    def test_invalid_subtag_name(self):
+        with self.assertRaises(exceptions.InvalidDiscoverableFeatureError):
+            class MyList(TaggedPatientList):
+                tag = 'foo'
+                subtag = 'one-two'


### PR DESCRIPTION
Add our feature validator for Tagged Patient Lists (no hyphens in tag names).

Turns out that if you try catch suppress the InvalidFeatureError, then those classes still come through when you iterate over __subclasses__. 

There is literally no good reason for an application to do that, however our tests do it repeatedly.

Accordingly we now run the simple pass is_valid method before yielding Feature subclasses.

Partially fixes #418 