### PR TITLE
fixes #999 the problem was that during the time it takes options to l…

### DIFF
--- a/opal/static/js/opal/controllers/patient_list_redirect.js
+++ b/opal/static/js/opal/controllers/patient_list_redirect.js
@@ -2,15 +2,16 @@ angular.module('opal.controllers').controller(
     'PatientListRedirectCtrl', function($scope, $cookieStore, $location, options){
         "use strict";
         // a simple controller that redirects to the correct tag/subtag
+        var target;
         $scope.ready = false;
 
         var path_base = '/list/';
         var last_list = $cookieStore.get('opal.lastPatientList');
         if(last_list){
-            var target = path_base + last_list;
+            target = path_base + last_list;
         }else{
-            var target = path_base + options.first_list_slug;
+            target = path_base + options.first_list_slug;
         }
-        $location.path( target + '/');
+        $location.path(target + '/');
         $location.replace();
 });

--- a/opal/static/js/opal/routes.js
+++ b/opal/static/js/opal/routes.js
@@ -5,7 +5,7 @@ app.config(
      function($routeProvider) {
          $routeProvider.when('/list/',{
              controller: 'PatientListRedirectCtrl',
-             templateUrl: '/templates/404.html',
+             templateUrl: '/templates/empty_page.html',
              resolve: {
                  options: function(Options){ return Options; }
              }

--- a/opal/templates/empty_page.html
+++ b/opal/templates/empty_page.html
@@ -1,0 +1,2 @@
+{% extends "opal.html" %}
+{% block content %}{% endblock %}


### PR DESCRIPTION
…oad it was showing the 404 page. Solution create an empty page template. We need to use an empty page template rather than just opal.html because the outer-container has a min height on it that shows as a grey rectangle while options are loading on firefox