### PR TITLE
Application styles

### DIFF
--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -108,6 +108,7 @@ class OpalApplication(object):
         ]
     }
     javascripts   = []
+    styles        = []
     actions       = []
     menuitems     = []
     default_episode_category = 'Inpatient'

--- a/opal/templates/base.html
+++ b/opal/templates/base.html
@@ -1,5 +1,6 @@
 {% load staticfiles %}
 {% load compress %}
+{% load opalplugins %}
 <!doctype html>
 <html>
 	<head>
@@ -18,9 +19,8 @@
 		    <link href="{% static "css/font-awesome/css/font-awesome.css" %}" rel="stylesheet" media="all">
 			<link href="{% static "css/opal.css" %}" rel="stylesheet" media="all">
 	        <link href="{% static "css/print.css" %}" rel="stylesheet" media="print">
+            {% application_stylesheets %}
         {% endcompress %}
-        {% if OPAL_EXTRA_APPLICATION %}{% include OPAL_EXTRA_APPLICATION %}{% endif %}
-
 	</head>
 	<body>
       {% block navbar %}{% include 'navbar.html' %}{% endblock %}

--- a/opal/templates/base.html
+++ b/opal/templates/base.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 {% load compress %}
-{% load opalplugins %}
+{% load application %}
 <!doctype html>
 <html>
 	<head>

--- a/opal/templates/navbar.html
+++ b/opal/templates/navbar.html
@@ -1,5 +1,7 @@
-{% load opalplugins %}
 {% load static %}
+
+{% load application %}
+{% load plugins %}
 <nav class="navbar navbar-default navbar-primary navbar-fixed-top screen-only top-navbar" role="navigation">
   <div class="container-fluid">
     <!-- Brand and toggle get grouped for better mobile display -->

--- a/opal/templates/opal.html
+++ b/opal/templates/opal.html
@@ -1,7 +1,8 @@
 {% load staticfiles %}
 {% load compress %}
 
-{% load opalplugins %}
+{% load application %}
+{% load plugins %}
 {% load gifs %}
 <!doctype html>
 {% block angulardefinition %}

--- a/opal/templates/opal.html
+++ b/opal/templates/opal.html
@@ -88,6 +88,7 @@
     <link href="{% static "css/screen.css" %}" rel="stylesheet" media="screen">
 
     {% plugin_stylesheets %}
+    {% application_stylesheets %}
 
     <link rel="shortcut icon" href="{% static 'img/ohc-icon.png' %}">
 

--- a/opal/templates/partials/_episode_actions.html
+++ b/opal/templates/partials/_episode_actions.html
@@ -1,4 +1,4 @@
-{% load opalplugins %}
+{% load application %}
 <p
    ng-hide="episode.category != 'Inpatient' || hide_discharge_action == true")
    >

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -1,0 +1,51 @@
+"""
+Templatetags for working with OPAL applications
+"""
+from django import template
+
+from opal.core import application
+
+register = template.Library()
+
+@register.inclusion_tag('plugins/menuitems.html')
+def application_menuitems():
+    def items():
+        app = application.get_app()
+        for i in app.menuitems:
+            yield i
+    return dict(items=items)
+
+@register.inclusion_tag('plugins/javascripts.html')
+def core_javascripts(namespace):
+    def scripts():
+        app = application.get_app()
+        for javascript in app.core_javascripts[namespace]:
+            yield javascript
+    return dict(javascripts=scripts)
+
+@register.inclusion_tag('plugins/javascripts.html')
+def application_javascripts():
+    def scripts():
+        app = application.get_app()
+        for javascript in app.javascripts:
+            yield javascript
+    return dict(javascripts=scripts)
+
+@register.inclusion_tag('plugins/stylesheets.html')
+def application_stylesheets():
+    def styles():
+        app = application.get_app()
+        for style in app.styles:
+            yield style
+    return dict(styles=styles)
+
+@register.inclusion_tag('plugins/actions.html')
+def application_actions():
+    def actions():
+        app = application.get_app()
+        for action in app.actions:
+            yield action
+        for plugin in plugins.plugins():
+            for action in plugin.actions:
+                yield action
+    return dict(actions=actions)

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -3,7 +3,7 @@ Templatetags for working with OPAL applications
 """
 from django import template
 
-from opal.core import application
+from opal.core import application, plugins
 
 register = template.Library()
 

--- a/opal/templatetags/opalplugins.py
+++ b/opal/templatetags/opalplugins.py
@@ -105,6 +105,14 @@ def application_javascripts():
             yield javascript
     return dict(javascripts=scripts)
 
+@register.inclusion_tag('plugins/stylesheets.html')
+def application_stylesheets():
+    def styles():
+        app = application.get_app()
+        for style in app.styles:
+            yield style
+    return dict(styles=styles)
+
 @register.inclusion_tag('plugins/actions.html')
 def application_actions():
     def actions():

--- a/opal/templatetags/plugins.py
+++ b/opal/templatetags/plugins.py
@@ -1,11 +1,11 @@
 """
-Templatetags for including OPAL plugins
+Templatetags for working with OPAL plugins
 """
 import itertools
 
 from django import template
 
-from opal.core import application, plugins
+from opal.core import plugins, application
 
 register = template.Library()
 
@@ -36,7 +36,6 @@ def plugin_head_extra(context):
     ctx['head_extra'] = templates
     return ctx
 
-
 def sort_menu_items(items):
     # sorting of menu item is done withan index property (lower = first), if they
     # don't have an index or if there are multiple with the same
@@ -46,7 +45,6 @@ def sort_menu_items(items):
     index_sorting = lambda x: x.get("index", 100)
     return sorted(sorted(items, key=alphabetic), key=index_sorting)
 
-
 @register.inclusion_tag('plugins/menuitems.html')
 def plugin_menuitems():
     def items():
@@ -55,15 +53,6 @@ def plugin_menuitems():
                 yield i
 
     return dict(items=sort_menu_items(items()))
-
-
-@register.inclusion_tag('plugins/menuitems.html')
-def application_menuitems():
-    def items():
-        app = application.get_app()
-        for i in app.menuitems:
-            yield i
-    return dict(items=items)
 
 @register.inclusion_tag('plugins/angular_module_deps.html')
 def plugin_opal_angular_deps():
@@ -88,38 +77,3 @@ def plugin_opal_angular_tracking_exclude():
         excluded_tracking_prefix=yield_property("opal_angular_exclude_tracking_prefix"),
         excluded_tracking_qs=yield_property("opal_angular_exclude_tracking_qs")
     )
-
-@register.inclusion_tag('plugins/javascripts.html')
-def core_javascripts(namespace):
-    def scripts():
-        app = application.get_app()
-        for javascript in app.core_javascripts[namespace]:
-            yield javascript
-    return dict(javascripts=scripts)
-
-@register.inclusion_tag('plugins/javascripts.html')
-def application_javascripts():
-    def scripts():
-        app = application.get_app()
-        for javascript in app.javascripts:
-            yield javascript
-    return dict(javascripts=scripts)
-
-@register.inclusion_tag('plugins/stylesheets.html')
-def application_stylesheets():
-    def styles():
-        app = application.get_app()
-        for style in app.styles:
-            yield style
-    return dict(styles=styles)
-
-@register.inclusion_tag('plugins/actions.html')
-def application_actions():
-    def actions():
-        app = application.get_app()
-        for action in app.actions:
-            yield action
-        for plugin in plugins.plugins():
-            for action in plugin.actions:
-                yield action
-    return dict(actions=actions)

--- a/opal/tests/test_templatetags_application.py
+++ b/opal/tests/test_templatetags_application.py
@@ -1,0 +1,57 @@
+"""
+Unittests for the opal.templatetags.application module
+"""
+from mock import patch, MagicMock
+
+from opal.core.test import OpalTestCase
+from opal.templatetags import application
+
+class ApplicationMenuitemsTestCase(OpalTestCase):
+
+    @patch('opal.templatetags.application.application.get_app')
+    def test_application_menuitems(self, get_app):
+        mock_app = MagicMock(name='Application')
+        mock_app.menuitems = [{'display': 'test'}]
+        get_app.return_value = mock_app
+        result = list(application.application_menuitems()['items']())
+        expected = [{'display': 'test'}]
+        self.assertEqual(expected, result)
+
+
+class CoreJavascriptTestCase(OpalTestCase):
+
+    @patch('opal.templatetags.application.application.get_app')
+    def test_core_javascripts(self, get_app):
+        mock_app = MagicMock(name='Application')
+        mock_app.core_javascripts = {'opal': ['test.js']}
+        get_app.return_value = mock_app
+
+        result = list(application.core_javascripts('opal')['javascripts']())
+
+        self.assertEqual(['test.js'], result)
+
+
+class ApplicationJavascriptTestCase(OpalTestCase):
+
+    @patch('opal.templatetags.application.application.get_app')
+    def test_core_javascripts(self, get_app):
+        mock_app = MagicMock(name='Application')
+        mock_app.javascripts = ['test.js']
+        get_app.return_value = mock_app
+
+        result = list(application.application_javascripts()['javascripts']())
+
+        self.assertEqual(['test.js'], result)
+
+
+class ApplicationStylesTestCase(OpalTestCase):
+
+    @patch('opal.templatetags.application.application.get_app')
+    def test_core_styles(self, get_app):
+        mock_app = MagicMock(name='Application')
+        mock_app.styles = ['test.css']
+        get_app.return_value = mock_app
+
+        result = list(application.application_stylesheets()['styles']())
+
+        self.assertEqual(['test.css'], result)

--- a/opal/tests/test_templatetags_plugins.py
+++ b/opal/tests/test_templatetags_plugins.py
@@ -116,3 +116,16 @@ class ApplicationJavascriptTestCase(OpalTestCase):
         result = list(opalplugins.application_javascripts()['javascripts']())
 
         self.assertEqual(['test.js'], result)
+
+
+class AppliationStylesTestCase(OpalTestCase):
+
+    @patch('opal.templatetags.opalplugins.application.get_app')
+    def test_core_styles(self, get_app):
+        mock_app = MagicMock(name='Application')
+        mock_app.styles = ['test.css']
+        get_app.return_value = mock_app
+
+        result = list(opalplugins.application_stylesheets()['styles']())
+
+        self.assertEqual(['test.css'], result)

--- a/opal/tests/test_templatetags_plugins.py
+++ b/opal/tests/test_templatetags_plugins.py
@@ -1,11 +1,11 @@
 """
-Unittests for the opal.templatetags.opalplugins module
+Unittests for the opal.templatetags.plugins module
 """
 from mock import patch, MagicMock
 
 from opal.core import plugins
 from opal.core.test import OpalTestCase
-from opal.templatetags import opalplugins
+from opal.templatetags import plugins as opalplugins
 
 class TestPlugin(plugins.OpalPlugin):
     javascripts = {
@@ -19,7 +19,7 @@ class TestPlugin(plugins.OpalPlugin):
 
 class PluginJavascriptsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.opalplugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.plugins')
     def test_plugin_javascripts(self, plugins):
         plugins.return_value = [TestPlugin]
         result = opalplugins.plugin_javascripts('opal.test')
@@ -32,7 +32,7 @@ class PluginJavascriptsTestCase(OpalTestCase):
 
 class PluginStylesheetsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.opalplugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.plugins')
     def test_plugin_stylesheets(self, plugins):
         plugins.return_value = [TestPlugin]
         css = list(opalplugins.plugin_stylesheets()['styles']())
@@ -41,7 +41,7 @@ class PluginStylesheetsTestCase(OpalTestCase):
 
 class PluginHeadExtraTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.opalplugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.plugins')
     def test_plugin_head_extra(self, plugins):
         plugins.return_value = [TestPlugin]
         context = opalplugins.plugin_head_extra({})
@@ -62,7 +62,7 @@ class MenuItemOrderingTest(OpalTestCase):
 
 class PluginMenuitemsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.opalplugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.plugins')
     def test_plugin_menuitems(self, plugins):
         plugins.return_value = [TestPlugin]
         menuitems = opalplugins.plugin_menuitems()['items']
@@ -70,62 +70,11 @@ class PluginMenuitemsTestCase(OpalTestCase):
         self.assertEqual(expected, menuitems)
 
 
-class ApplicationMenuitemsTestCase(OpalTestCase):
-
-    @patch('opal.templatetags.opalplugins.application.get_app')
-    def test_application_menuitems(self, get_app):
-        mock_app = MagicMock(name='Application')
-        mock_app.menuitems = [{'display': 'test'}]
-        get_app.return_value = mock_app
-        result = list(opalplugins.application_menuitems()['items']())
-        expected = [{'display': 'test'}]
-        self.assertEqual(expected, result)
-
-
 class PluginAngularDepsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.opalplugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.plugins')
     def test_plugin_angular_deps(self, plugins):
         plugins.return_value = [TestPlugin]
         deps = list(opalplugins.plugin_opal_angular_deps()['deps']())
         expected = ['js/test.angular.mod.js']
         self.assertEqual(expected, deps)
-
-
-class CoreJavascriptTestCase(OpalTestCase):
-
-    @patch('opal.templatetags.opalplugins.application.get_app')
-    def test_core_javascripts(self, get_app):
-        mock_app = MagicMock(name='Application')
-        mock_app.core_javascripts = {'opal': ['test.js']}
-        get_app.return_value = mock_app
-
-        result = list(opalplugins.core_javascripts('opal')['javascripts']())
-
-        self.assertEqual(['test.js'], result)
-
-
-class ApplicationJavascriptTestCase(OpalTestCase):
-
-    @patch('opal.templatetags.opalplugins.application.get_app')
-    def test_core_javascripts(self, get_app):
-        mock_app = MagicMock(name='Application')
-        mock_app.javascripts = ['test.js']
-        get_app.return_value = mock_app
-
-        result = list(opalplugins.application_javascripts()['javascripts']())
-
-        self.assertEqual(['test.js'], result)
-
-
-class AppliationStylesTestCase(OpalTestCase):
-
-    @patch('opal.templatetags.opalplugins.application.get_app')
-    def test_core_styles(self, get_app):
-        mock_app = MagicMock(name='Application')
-        mock_app.styles = ['test.css']
-        get_app.return_value = mock_app
-
-        result = list(opalplugins.application_stylesheets()['styles']())
-
-        self.assertEqual(['test.css'], result)

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'djangorestframework==3.2.2',
         'django-compressor==1.5',
         'python-dateutil==2.4.2',
-        'Fabric==1.10.2'
+        'Fabric==1.10.2',
+        'pycrypto==2.6.1',
         ]
 )


### PR DESCRIPTION
Add a `.styles` property to `opal.core.Application` and include the contents in both `base.html` and `opal.html`.

This is required to make skinning the default OPAL styles as trivial as it should be.

This PR also refactors the increasingly inaccurately named `opal.templatetags.opalplugins` into two different modules.