### PR TITLE
Improve the Developer API for application static assets

### DIFF
--- a/doc/docs/reference/opal_application.md
+++ b/doc/docs/reference/opal_application.md
@@ -1,6 +1,6 @@
 # opal.core.application
 
-##OpalApplication
+## OpalApplication
 
 The base class for your main application entrypoints is opal.core.application.OpalApplication.
 
@@ -9,16 +9,30 @@ You must subclass this in order for OPAL to discover your application.
 If you started your OPAL project via `$ opal startproject yourproject` then this will have been
 generated for you, and located in `yourproject/yourproject/__init__.py`
 
-### schema_module
+### Properties
 
-### javascripts
+#### OpalApplication.actions
 
-### actions
+#### OpalApplication.default_episode_category
 
-### menuitems
+The default category is 'Inpatient', but can be overridden in the
+[OpalApplication](opal_application.md) subclass for your implementation.
+
+#### OpalApplication.javascripts
+
+#### OpalApplication.menuitems
 
 A list of items to add to the top level menu
 
-### default_episode_category
+#### OpalApplication.styles
 
-The default category is either 'inpatient', but can be overridden in the [OpalApplication](opal_application.md) subclass for your implementation.
+### Classmethods
+
+#### OpalApplication.get_core_javascripts(namespace)
+
+Return a list of the core javascript files specified within a given namespace.
+
+    application.get_core_javascripts('opal.utils')
+    # -> ['js/opal/utils.js', ...]
+
+#### OpalApplication.get_menu_items()

--- a/doc/docs/reference/opal_application.md
+++ b/doc/docs/reference/opal_application.md
@@ -11,6 +11,8 @@ generated for you, and located in `yourproject/yourproject/__init__.py`
 
 ### Properties
 
+Properties available on an OpalApplication:
+
 #### OpalApplication.actions
 
 #### OpalApplication.default_episode_category
@@ -20,6 +22,14 @@ The default category is 'Inpatient', but can be overridden in the
 
 #### OpalApplication.javascripts
 
+A list of javascripts that our application would like to include. These should be strings
+representing paths ready for staticfiles. Defaults to `[]`.
+
+```python
+class MyApplication(OpalApplication):
+    javascripts = ['js/one.js']
+```
+
 #### OpalApplication.menuitems
 
 A list of items to add to the top level menu
@@ -28,11 +38,26 @@ A list of items to add to the top level menu
 
 ### Classmethods
 
+Classmethod API for OpalApplication instances:
+
 #### OpalApplication.get_core_javascripts(namespace)
 
-Return a list of the core javascript files specified within a given namespace.
+Return a list of the core javascript files specified within a given namespace. These wil be
+relative paths ready for staticfiles.
 
-    application.get_core_javascripts('opal.utils')
-    # -> ['js/opal/utils.js', ...]
+```python
+application.get_core_javascripts('opal.utils')
+# -> ['js/opal/utils.js', ...]
+```
+
+#### OpalApplication.get_javascripts()
+
+Return a list of the application's javasctipts as paths to them ready for staticfiles.
+Defaults to returning the OpalApplication.javascripts property.
+
+```python
+application.get_javascripts()
+# -> ['js/one.js', 'js/two.js', ...]
+```
 
 #### OpalApplication.get_menu_items()

--- a/doc/docs/reference/opal_application.md
+++ b/doc/docs/reference/opal_application.md
@@ -36,6 +36,15 @@ A list of items to add to the top level menu
 
 #### OpalApplication.styles
 
+A list of stylesheets that our application would like to include. These should be strings
+representing paths ready for staticfiles. Defaults to `[]`. These styles are included after
+the default OPAL styles.
+
+```python
+class MyApplication(OpalApplication):
+    styles = ['css/app.css']
+```
+
 ### Classmethods
 
 Classmethod API for OpalApplication instances:
@@ -53,7 +62,7 @@ application.get_core_javascripts('opal.utils')
 #### OpalApplication.get_javascripts()
 
 Return a list of the application's javasctipts as paths to them ready for staticfiles.
-Defaults to returning the OpalApplication.javascripts property.
+Defaults to returning the `OpalApplication.javascripts` property.
 
 ```python
 application.get_javascripts()
@@ -61,3 +70,13 @@ application.get_javascripts()
 ```
 
 #### OpalApplication.get_menu_items()
+
+#### OpalApplication.get_styles()
+
+Return a list of the application's stylesheets as paths to them ready for staticfiles.
+Defaults to returning the contents of `OpalApplication.styles`.
+
+```python
+application.get_styles()
+# -> ['css/app.css', ...]
+```

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -60,3 +60,6 @@ include_next_prev: false
 
 extra:
   version: v0.7.0
+
+markdown_extensions:
+    - fenced_code

--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -139,6 +139,14 @@ class OpalApplication(object):
         """
         return klass.menuitems
 
+    @classmethod
+    def get_styles(klass):
+        """
+        Return the stylesheets for our application
+        """
+        return klass.styles
+
+
 
 def get_app():
     """

--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -123,6 +123,13 @@ class OpalApplication(object):
         return klass.core_javascripts[namespace]
 
     @classmethod
+    def get_javascripts(klass):
+        """
+        Return the javascripts for our application
+        """
+        return klass.javascripts
+
+    @classmethod
     def get_menu_items(klass):
         """
         Default implementation of get_menu_items()

--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -116,6 +116,13 @@ class OpalApplication(object):
     ]
 
     @classmethod
+    def get_core_javascripts(klass, namespace):
+        """
+        Return core javascripts for a given NAMESPACE
+        """
+        return klass.core_javascripts[namespace]
+
+    @classmethod
     def get_menu_items(klass):
         """
         Default implementation of get_menu_items()

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -19,7 +19,7 @@ def application_menuitems():
 def core_javascripts(namespace):
     def scripts():
         app = application.get_app()
-        for javascript in app.core_javascripts[namespace]:
+        for javascript in app.get_core_javascripts(namespace):
             yield javascript
     return dict(javascripts=scripts)
 

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -35,7 +35,7 @@ def application_javascripts():
 def application_stylesheets():
     def styles():
         app = application.get_app()
-        for style in app.styles:
+        for style in app.get_styles():
             yield style
     return dict(styles=styles)
 

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -27,7 +27,7 @@ def core_javascripts(namespace):
 def application_javascripts():
     def scripts():
         app = application.get_app()
-        for javascript in app.javascripts:
+        for javascript in app.get_javascripts():
             yield javascript
     return dict(javascripts=scripts)
 

--- a/opal/tests/test_core_application.py
+++ b/opal/tests/test_core_application.py
@@ -11,10 +11,36 @@ class OpalApplicationTestCase(TestCase):
         class App(application.OpalApplication):
             flow_module = 'opal.tests.flows'
 
+
         self.app = App
 
+    def test_get_core_javascripts(self):
+        expected = [
+            "js/opal/controllers_module.js",
+            "js/opal/controllers/patient_list_redirect.js",
+            "js/opal/controllers/patient_list.js",
+            "js/opal/controllers/episode_detail.js",
+            "js/opal/controllers/patient_detail.js",
+            "js/opal/controllers/hospital_number.js",
+            "js/opal/controllers/add_episode.js",
+            "js/opal/controllers/reopen_episode.js",
+            "js/opal/controllers/edit_item.js",
+            "js/opal/controllers/edit_teams.js",
+            "js/opal/controllers/delete_item_confirmation.js",
+            "js/opal/controllers/account.js",
+            "js/opal/controllers/undischarge.js",
+            "js/opal/controllers/copy_to_category.js",
+            "js/opal/controllers/keyboard_shortcuts.js",
+            "js/opal/controllers/patient_access_log.js"
+        ]
+        self.assertEqual(
+            expected,
+            self.app.get_core_javascripts('opal.controllers'))
+
     def test_get_menu_items(self):
-        self.assertEqual([], application.OpalApplication.get_menu_items())
+        self.assertEqual(
+            [],
+            application.OpalApplication.get_menu_items())
 
 
 

--- a/opal/tests/test_core_application.py
+++ b/opal/tests/test_core_application.py
@@ -10,6 +10,7 @@ class OpalApplicationTestCase(TestCase):
     def setUp(self):
         class App(application.OpalApplication):
             flow_module = 'opal.tests.flows'
+            javascripts = ['test.js']
 
 
         self.app = App
@@ -36,6 +37,9 @@ class OpalApplicationTestCase(TestCase):
         self.assertEqual(
             expected,
             self.app.get_core_javascripts('opal.controllers'))
+
+    def test_get_javascripts(self):
+        self.assertEqual(['test.js'], self.app.get_javascripts())
 
     def test_get_menu_items(self):
         self.assertEqual(

--- a/opal/tests/test_core_application.py
+++ b/opal/tests/test_core_application.py
@@ -11,6 +11,7 @@ class OpalApplicationTestCase(TestCase):
         class App(application.OpalApplication):
             flow_module = 'opal.tests.flows'
             javascripts = ['test.js']
+            styles = ['app.css']
 
 
         self.app = App
@@ -45,6 +46,9 @@ class OpalApplicationTestCase(TestCase):
         self.assertEqual(
             [],
             application.OpalApplication.get_menu_items())
+
+    def test_get_styles(self):
+        self.assertEqual(['app.css'], self.app.get_styles())
 
 
 

--- a/opal/tests/test_templatetags_application.py
+++ b/opal/tests/test_templatetags_application.py
@@ -23,12 +23,13 @@ class CoreJavascriptTestCase(OpalTestCase):
     @patch('opal.templatetags.application.application.get_app')
     def test_core_javascripts(self, get_app):
         mock_app = MagicMock(name='Application')
-        mock_app.core_javascripts = {'opal': ['test.js']}
+        mock_app.get_core_javascripts.return_value = ['test.js']
         get_app.return_value = mock_app
 
         result = list(application.core_javascripts('opal')['javascripts']())
 
         self.assertEqual(['test.js'], result)
+        mock_app.get_core_javascripts.assert_called_with('opal')
 
 
 class ApplicationJavascriptTestCase(OpalTestCase):

--- a/opal/tests/test_templatetags_application.py
+++ b/opal/tests/test_templatetags_application.py
@@ -37,12 +37,13 @@ class ApplicationJavascriptTestCase(OpalTestCase):
     @patch('opal.templatetags.application.application.get_app')
     def test_core_javascripts(self, get_app):
         mock_app = MagicMock(name='Application')
-        mock_app.javascripts = ['test.js']
+        mock_app.get_javascripts.return_value = ['test.js']
         get_app.return_value = mock_app
 
         result = list(application.application_javascripts()['javascripts']())
 
         self.assertEqual(['test.js'], result)
+        mock_app.get_javascripts.assert_called_with()
 
 
 class ApplicationStylesTestCase(OpalTestCase):

--- a/opal/tests/test_templatetags_application.py
+++ b/opal/tests/test_templatetags_application.py
@@ -51,9 +51,10 @@ class ApplicationStylesTestCase(OpalTestCase):
     @patch('opal.templatetags.application.application.get_app')
     def test_core_styles(self, get_app):
         mock_app = MagicMock(name='Application')
-        mock_app.styles = ['test.css']
+        mock_app.get_styles.return_value = ['test.css']
         get_app.return_value = mock_app
 
         result = list(application.application_stylesheets()['styles']())
 
         self.assertEqual(['test.css'], result)
+        mock_app.get_styles.assert_called_with()


### PR DESCRIPTION
Creates some indirection in the way that OpalApplication fetches static assets.
Allows developers an entrypoint to customise this.
Improves documentation of opal.core.application.OpalApplication