### PR TITLE
Add new APIs and a Metadata discoverable

### DIFF
--- a/opal/core/metadata.py
+++ b/opal/core/metadata.py
@@ -1,0 +1,102 @@
+"""
+Allowing us to define application medatada that we can
+serve to client applications via a JSON API.
+
+We also define some metadata defaults that we don't currently have
+better places for.
+
+These should eventually be moved out.
+"""
+from opal.core import discoverable
+
+class Metadata(discoverable.DiscoverableFeature):
+    module_name = 'medatada'
+
+class MacrosMetadata(Metadata):
+    slug = 'macros'
+
+    @classmethod
+    def to_dict(klass, **kw):
+        from opal.models import Macro
+
+        return {
+            klass.slug: Macro.to_dict()
+        }
+
+class MicroTestDefaultsMetadata(Metadata):
+    slug = 'micro_test_defaults'
+
+    @classmethod
+    def to_dict(klass, **kw):
+        return {
+            klass.slug: {
+                'micro_test_serology': {
+                    'igm': 'pending',
+                    'igg': 'pending'
+                },
+                'micro_test_ebv_serology': {
+                    'vca_igm' : 'pending',
+                    'vca_igg' : 'pending',
+                    'ebna_igg': 'pending'
+                },
+                'micro_test_hiv': {
+                    'result': 'pending'
+                },
+                'micro_test_hepititis_b_serology': {
+                    'hbsag'          : 'pending',
+                    'anti_hbs'       : 'pending',
+                    'anti_hbcore_igm': 'pending',
+                    'anti_hbcore_igg': 'pending'
+                },
+                'micro_test_syphilis_serology': {
+                    'tppa': 'pending'
+                },
+                'micro_test_single_test_pos_neg': {
+                    'result': 'pending'
+                },
+                'micro_test_single_test_pos_neg_equiv': {
+                    'result': 'pending'
+                },
+                'micro_test_single_igg_test': {
+                    'result': 'pending'
+                },
+                'micro_test_swab_pcr': {
+                    'hsv': 'pending',
+                    'vzv': 'pending',
+                    'syphilis': 'pending'
+                },
+                'micro_test_c_difficile': {
+                    'c_difficile_antigen': 'pending',
+                    'c_difficile_toxin': 'pending'
+                },
+                'micro_test_leishmaniasis_pcr': {
+                    'result': 'pending'
+                },
+                'micro_test_csf_pcr': {
+                    'hsv_1': 'pending',
+                    'hsv_2': 'pending',
+                    'enterovirus': 'pending',
+                    'cmv': 'pending',
+                    'ebv': 'pending',
+                    'vzv': 'pending'
+                },
+                'micro_test_respiratory_virus_pcr': {
+                    'influenza_a': 'pending',
+                    'influenza_b': 'pending',
+                    'parainfluenza': 'pending',
+                    'metapneumovirus': 'pending',
+                    'rsv': 'pending',
+                    'adenovirus': 'pending',
+                },
+                'micro_test_stool_pcr': {
+                    'norovirus': 'pending',
+                    'rotavirus': 'pending',
+                    'adenovirus': 'pending',
+                },
+                'micro_test_stool_parasitology_pcr': {
+                    'giardia': 'pending',
+                    'entamoeba_histolytica': 'pending',
+                    'cryptosporidium': 'pending'
+                }
+            }
+        }

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -138,6 +138,42 @@ class OptionTestCase(TestCase):
         self.assertEqual(expected, result['tags'])
 
 
+class ReferenceDataViewSetTestCase(OpalTestCase):
+
+    def setUp(self):
+        self.top = Hat.objects.create(name="top")
+        self.bowler = Hat.objects.create(name="bowler")
+        self.synonym_name = "high"
+        self.user = User.objects.create(username='testuser')
+        content_type = ContentType.objects.get_for_model(Hat)
+        models.Synonym.objects.get_or_create(
+            content_type=content_type,
+            object_id=self.top.id,
+            name=self.synonym_name
+        )
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        self.request = mock_request
+        self.viewset = api.ReferenceDataViewSet()
+        self.viewset.request = mock_request
+
+    def test_list(self):
+        self.response = self.viewset.list(self.request)
+        result = self.response.data
+        self.assertIn("hat", result)
+        self.assertEqual(set(result["hat"]), {"top", "bowler", "high"})
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_get(self):
+        response = self.viewset.retrieve(self.request, pk='hat')
+        self.assertEqual(set(response.data), {"top", "bowler", "high"})
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_does_not_exist(self):
+        response = self.viewset.retrieve(self.request, pk='notalookuplist')
+        self.assertEqual(response.status_code, 404)
+
+
 class SubrecordTestCase(TestCase):
 
     def setUp(self):

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -12,6 +12,7 @@ from mock import patch, MagicMock
 
 from opal import models
 from opal.tests.models import Colour, PatientColour, HatWearer, Hat
+from opal.core import metadata
 from opal.core.test import OpalTestCase
 from opal.core.views import _build_json_response
 
@@ -172,6 +173,30 @@ class ReferenceDataViewSetTestCase(OpalTestCase):
     def test_get_does_not_exist(self):
         response = self.viewset.retrieve(self.request, pk='notalookuplist')
         self.assertEqual(response.status_code, 404)
+
+
+class MetadataViewSetTestCase(OpalTestCase):
+    def test_list(self):
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        response = api.MetadataViewSet().list(mock_request)
+        self.assertEqual(200, response.status_code)
+        for s in metadata.Metadata.list():
+            for key, value in s.to_dict(user=self.user).items():
+                self.assertEqual(response.data[key], value)
+
+    def test_retrieve(self):
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        response = api.MetadataViewSet().retrieve(mock_request, pk='macros')
+        self.assertEqual(200, response.status_code)
+        self.assertIn('macros', response.data)
+
+    def test_retrieve_nonexistent_metadata(self):
+        mock_request = MagicMock(name='mock request')
+        mock_request.user = self.user
+        response = api.MetadataViewSet().retrieve(mock_request, pk='notarealmetadata')
+        self.assertEqual(404, response.status_code)
 
 
 class SubrecordTestCase(TestCase):

--- a/opal/tests/test_core_metadata.py
+++ b/opal/tests/test_core_metadata.py
@@ -1,0 +1,27 @@
+"""
+Unittests for the opal.core.metadata module
+"""
+from opal import models
+from opal.core.test import OpalTestCase
+
+from opal.core import metadata
+
+class MacroMetadataTestCase(OpalTestCase):
+
+    def test_to_dict(self):
+        macro = models.Macro(title='the title', expanded='the expanded')
+        macro.save()
+        expected = {
+            'macros': [{'expanded': 'the expanded', 'label': 'the title'}]
+        }
+        self.assertEqual(expected, metadata.MacrosMetadata.to_dict())
+
+class MicoTestDefaultsTestCase(OpalTestCase):
+
+    def test_to_dict(self):
+        expected = {
+                    'igm': 'pending',
+                    'igg': 'pending'
+                }
+        as_dict = metadata.MicroTestDefaultsMetadata.to_dict()
+        self.assertEqual(expected, as_dict['micro_test_defaults']['micro_test_serology'])


### PR DESCRIPTION
Adds specific /referencedata/ and /metadata/ API endpoints. 
We can now fetch these individually rather than having to always get the entire application's meta and reference data at once.
We now have a `Metadata` discoverable - which goes a long way to addressing #462 (as you may now add to the /metadata/ JSON endpoint by implementing your own Metadata subclass).

/options/ remains in place for now, although the implementation re-uses `Metadata` where that makes sense.

We expect to remove that after subsequent PRs to 
* Establish front end services for Metadata and Referencedata
* Switch Angular code to use the new front end data services