### PR TITLE
If there are no PatientLists for a given user, 

### DIFF
--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -161,9 +161,14 @@ class OptionsViewSet(viewsets.ViewSet):
             direct_add=True,
         )
 
-        data['first_list_slug'] = next(
-            PatientList.for_user(self.request.user)
-        ).get_slug()
+        try:
+            first_list_slug = next(
+                PatientList.for_user(self.request.user)
+            ).get_slug()
+        except StopIteration: # There are no PatientLists for this user
+            first_list_slug = ''
+
+        data['first_list_slug'] = first_list_slug
 
         data['macros'] = Macro.to_dict()
 

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -70,9 +70,10 @@ class OptionTestCase(TestCase):
         mock_request = MagicMock(name='mock request')
         mock_request.user = self.user
         request = mock_request
-        viewset = api.OptionsViewSet()
-        viewset.request = mock_request
-        self.response = viewset.list(request)
+        self.request = request
+        self.viewset = api.OptionsViewSet()
+        self.viewset.request = mock_request
+        self.response = self.viewset.list(request)
 
     def test_options_loader(self):
         result = self.response.data
@@ -83,6 +84,16 @@ class OptionTestCase(TestCase):
     def test_first_list_slug(self):
         result = self.response.data
         self.assertEqual('carnivore', result['first_list_slug'])
+
+    def test_first_list_slug_no_lists(self):
+        def nongen():
+            for x in range(0, 0):
+                yield x
+
+        with patch.object(api.PatientList, 'for_user') as for_user:
+            for_user.return_value = nongen()
+            result = self.viewset.list(self.request).data
+            self.assertEqual('', result['first_list_slug'])
 
     def test_tag_display(self):
         result = self.response.data


### PR DESCRIPTION
that shouldn't really be enough to cause /api/v0.1/options/ to throw a 500.