### PR TITLE
Don't manually create _lists in multiple places

### DIFF
--- a/opal/core/search/static/js/search/controllers/extract.js
+++ b/opal/core/search/static/js/search/controllers/extract.js
@@ -1,270 +1,270 @@
 angular.module('opal.controllers').controller(
     'ExtractCtrl', function($scope, $http, $window, $modal, $timeout,
-                            PatientSummary, Paginator,
+                            PatientSummary, Paginator, Referencedata,
                             ngProgressLite, profile, filters, options, schema){
 
-        var underscoreToCapWords = function(str) {
-            return str.toLowerCase().replace(/_/g, ' ').replace(
-                    /(?:\b)(\w)/g, function(s, p){ return p.toUpperCase(); });
-        };
+        Referencedata.then(function(referencedata){
 
-        $scope.profile = profile;
-        $scope.limit = 10;
-        $scope.JSON = window.JSON;
-        $scope.filters = filters;
-        $scope.columns = schema.getAdvancedSearchColumns();
-        $scope.searched = false;
-        $scope.currentPageNumber = 1;
-        $scope.paginator = new Paginator($scope.search);
+            var underscoreToCapWords = function(str) {
+                return str.toLowerCase().replace(/_/g, ' ').replace(
+                        /(?:\b)(\w)/g, function(s, p){ return p.toUpperCase(); });
+            };
 
-        // todo, remove symptom from here
-        NOT_ADVANCED_SEARCHABLE = [
-          "created", "updated", "created_by_id", "updated_by_id"
-        ];
-
-	    for (var name in options) {
-		    $scope[name + '_list'] = options[name];
-	    };
-
-        $scope.model = {
-            combine    : "and",
-            column     : null,
-            field      : null,
-            queryType  : null,
-            query      : null,
-            lookup_list: []
-        };
-
-        $scope.criteria = [_.clone($scope.model)];
-
-        $scope.completeCriteria =  function(){
-            return _.filter($scope.criteria, function(c){
-                // Teams are a special case - they are essentially boolean
-                if(c.column == 'tagging' && c.field){
-                    return true
-                }
-                // Ensure we have a query otherwise
-                if(c.column &&  c.field &&  c.query){
-                    return true
-                }
-                // If not, we ignore this clause
-                return false
-            })
-        };
-
-        $scope.searchableFields = function(column){
-            // TODO - don't hard-code this
-            if(column.name == 'microbiology_test'){
-                return [
-                    'Test',
-                    'Date Ordered',
-                    'Details',
-                    'Microscopy',
-                    'Organism',
-                    'Sensitive Antibiotics',
-                    'Resistant Antibiotics'
-                ]
-            }
-            return _.map(
-                _.reject(
-                    column.fields,
-                    function(c){
-                      if(_.contains(NOT_ADVANCED_SEARCHABLE, c.name)){
-                        return true;
-                      }
-                      return c.type == 'token' ||  c.type ==  'list';
-                    }),
-                function(c){ return underscoreToCapWords(c.name); }
-            ).sort();
-        };
-
-        $scope.isType = function(column, field, type){
-            if(!column || !field){
-                return false;
-            }
-            var col = _.find(
-                $scope.columns,
-                function(item){
-                    return item.name == column.toLowerCase().replace( / /g,  '_')
-                });
-            var theField =  _.find(
-                col.fields,
-                function(f){
-                    return f.name == field.toLowerCase().replace( / /g,  '_')
-                });
-            if(!theField){ return false }
-            if (_.isArray(type)){
-                var match = false;
-                _.each(type, function(t){ if(t == theField.type){ match = true} });
-                return match;
-            }else{
-                return theField.type == type;
-            }
-        };
-
-        $scope.isBoolean = function(column, field){
-            return $scope.isType(column, field, ["boolean", "null_boolean"]);
-        };
-
-        $scope.isText = function(column, field){
-            return $scope.isType(column, field, "string") || $scope.isType(column, field, "text");
-        }
-
-        $scope.isSelect = function(column, field){
-            return $scope.isType(column, field, "many_to_many");
-        };
-
-        $scope.isDate = function(column, field){
-            return $scope.isType(column, field, "date");
-        };
-
-        $scope.addFilter = function(){
+            $scope.profile = profile;
+            $scope.limit = 10;
+            $scope.JSON = window.JSON;
+            $scope.filters = filters;
+            $scope.columns = schema.getAdvancedSearchColumns();
             $scope.searched = false;
-            $scope.criteria.push(_.clone($scope.model));
-        };
+            $scope.currentPageNumber = 1;
+            $scope.paginator = new Paginator($scope.search);
 
-        $scope.removeFilter = function(index){
-            if($scope.criteria.length == 1){
-                return
-            }
-            $scope.searched = false;
-            $scope.criteria.splice(index, 1);
-        };
+            // todo, remove symptom from here
+            NOT_ADVANCED_SEARCHABLE = [
+                "created", "updated", "created_by_id", "updated_by_id"
+            ];
+            _.extend($scope, referencedata.toLookuplists());
 
-        $scope.resetFilter = function(index, dontReset){
-            for (k in $scope.model) {
-                if (dontReset.indexOf(k) == -1) {
-                    $scope.criteria[index][k] = $scope.model[k];
-                }
-            }
-        };
+            $scope.model = {
+                combine    : "and",
+                column     : null,
+                field      : null,
+                queryType  : null,
+                query      : null,
+                lookup_list: []
+            };
 
-        $scope.removeCriteria = function(){
-            $scope.searched = false;
             $scope.criteria = [_.clone($scope.model)];
-        };
 
-        //
-        // Determine the appropriate lookup list for this field if
-        // one exists.
-        //
-        $scope._lookuplist_watch = function(){
-            _.map($scope.criteria, function(c){
-                var column = _.findWhere($scope.columns, {name: c.column});
-                if(!column){return}
-                if(!c.field){return}
-                var field = _.findWhere(
-                    column.fields, {name: c.field.toLowerCase().replace(/ /g, '_')});
-                if(!field){return}
-                if(field.lookup_list){
-                    c.lookup_list = $scope[field.lookup_list + '_list'];
+            $scope.completeCriteria =  function(){
+                return _.filter($scope.criteria, function(c){
+                    // Teams are a special case - they are essentially boolean
+                    if(c.column == 'tagging' && c.field){
+                        return true
+                    }
+                    // Ensure we have a query otherwise
+                    if(c.column &&  c.field &&  c.query){
+                        return true
+                    }
+                    // If not, we ignore this clause
+                    return false
+                })
+            };
+
+            $scope.searchableFields = function(column){
+                // TODO - don't hard-code this
+                if(column.name == 'microbiology_test'){
+                    return [
+                        'Test',
+                        'Date Ordered',
+                        'Details',
+                        'Microscopy',
+                        'Organism',
+                        'Sensitive Antibiotics',
+                        'Resistant Antibiotics'
+                    ]
                 }
-            });
-            $scope.async_waiting = false;
-            $scope.async_ready = false;
-        }
+                return _.map(
+                    _.reject(
+                        column.fields,
+                        function(c){
+                            if(_.contains(NOT_ADVANCED_SEARCHABLE, c.name)){
+                                return true;
+                            }
+                            return c.type == 'token' ||  c.type ==  'list';
+                        }),
+                    function(c){ return underscoreToCapWords(c.name); }
+                ).sort();
+            };
 
-        $scope.$watch('criteria', $scope._lookuplist_watch, true);
-
-        $scope.search = function(pageNumber){
-            if(!pageNumber){
-                pageNumber = 1;
-            }
-
-            var queryParams = $scope.completeCriteria();
-
-            if(queryParams.length){
-                queryParams[0].page_number = pageNumber;
-            }
-            ngProgressLite.set(0);
-            ngProgressLite.start();
-            $http.post('/search/extract/', queryParams).success(
-                function(response){
-                    $scope.results = _.map(response.object_list, function(o){
-                        return new PatientSummary(o);
+            $scope.isType = function(column, field, type){
+                if(!column || !field){
+                    return false;
+                }
+                var col = _.find(
+                    $scope.columns,
+                    function(item){
+                        return item.name == column.toLowerCase().replace( / /g,  '_')
                     });
-                    $scope.searched = true;
-                    $scope.paginator = new Paginator($scope.search, response);
-                    ngProgressLite.done();
-                }).error(function(e){
-                    ngProgressLite.set(0);
-                    $window.alert('ERROR: Could not process this search. Please report it to the OPAL team')
-                });
-        };
+                var theField =  _.find(
+                    col.fields,
+                    function(f){
+                        return f.name == field.toLowerCase().replace( / /g,  '_')
+                    });
+                if(!theField){ return false }
+                if (_.isArray(type)){
+                    var match = false;
+                    _.each(type, function(t){ if(t == theField.type){ match = true} });
+                    return match;
+                }else{
+                    return theField.type == type;
+                }
+            };
 
-        $scope.async_extract = function(){
-            if($scope.async_ready){
-                $window.open('/search/extract/download/' + $scope.extract_id, '_blank');
-                return null
-            }
-            if($scope.async_waiting){
-                return null
+            $scope.isBoolean = function(column, field){
+                return $scope.isType(column, field, ["boolean", "null_boolean"]);
+            };
+
+            $scope.isText = function(column, field){
+                return $scope.isType(column, field, "string") || $scope.isType(column, field, "text");
             }
 
-            var ping_until_success = function(){
-                if(!$scope.extract_id){
-                    $timeout(ping_until_success, 1000)
+            $scope.isSelect = function(column, field){
+                return $scope.isType(column, field, "many_to_many");
+            };
+
+            $scope.isDate = function(column, field){
+                return $scope.isType(column, field, "date");
+            };
+
+            $scope.addFilter = function(){
+                $scope.searched = false;
+                $scope.criteria.push(_.clone($scope.model));
+            };
+
+            $scope.removeFilter = function(index){
+                if($scope.criteria.length == 1){
                     return
                 }
-                $http.get('/search/extract/result/'+ $scope.extract_id).then(function(result){
-                    if(result.data.state == 'FAILURE'){
-                        $window.alert('FAILURE')
-                        $scope.async_waiting = false;
+                $scope.searched = false;
+                $scope.criteria.splice(index, 1);
+            };
+
+            $scope.resetFilter = function(index, dontReset){
+                for (k in $scope.model) {
+                    if (dontReset.indexOf(k) == -1) {
+                        $scope.criteria[index][k] = $scope.model[k];
+                    }
+                }
+            };
+
+            $scope.removeCriteria = function(){
+                $scope.searched = false;
+                $scope.criteria = [_.clone($scope.model)];
+            };
+
+            //
+            // Determine the appropriate lookup list for this field if
+            // one exists.
+            //
+            $scope._lookuplist_watch = function(){
+                _.map($scope.criteria, function(c){
+                    var column = _.findWhere($scope.columns, {name: c.column});
+                    if(!column){return}
+                    if(!c.field){return}
+                    var field = _.findWhere(
+                        column.fields, {name: c.field.toLowerCase().replace(/ /g, '_')});
+                    if(!field){return}
+                    if(field.lookup_list){
+                        c.lookup_list = $scope[field.lookup_list + '_list'];
+                    }
+                });
+                $scope.async_waiting = false;
+                $scope.async_ready = false;
+            }
+
+            $scope.$watch('criteria', $scope._lookuplist_watch, true);
+
+            $scope.search = function(pageNumber){
+                if(!pageNumber){
+                    pageNumber = 1;
+                }
+
+                var queryParams = $scope.completeCriteria();
+
+                if(queryParams.length){
+                    queryParams[0].page_number = pageNumber;
+                }
+                ngProgressLite.set(0);
+                ngProgressLite.start();
+                $http.post('/search/extract/', queryParams).success(
+                    function(response){
+                        $scope.results = _.map(response.object_list, function(o){
+                            return new PatientSummary(o);
+                        });
+                        $scope.searched = true;
+                        $scope.paginator = new Paginator($scope.search, response);
+                        ngProgressLite.done();
+                    }).error(function(e){
+                        ngProgressLite.set(0);
+                        $window.alert('ERROR: Could not process this search. Please report it to the OPAL team')
+                    });
+            };
+
+            $scope.async_extract = function(){
+                if($scope.async_ready){
+                    $window.open('/search/extract/download/' + $scope.extract_id, '_blank');
+                    return null
+                }
+                if($scope.async_waiting){
+                    return null
+                }
+
+                var ping_until_success = function(){
+                    if(!$scope.extract_id){
+                        $timeout(ping_until_success, 1000)
                         return
                     }
-                    if(result.data.state == 'SUCCESS'){
-                        $scope.async_ready = true;
-                    }else{
-                        if($scope.async_waiting){
-                            $timeout(ping_until_success, 1000)
+                    $http.get('/search/extract/result/'+ $scope.extract_id).then(function(result){
+                        if(result.data.state == 'FAILURE'){
+                            $window.alert('FAILURE')
+                            $scope.async_waiting = false;
+                            return
                         }
-                    }
+                        if(result.data.state == 'SUCCESS'){
+                            $scope.async_ready = true;
+                        }else{
+                            if($scope.async_waiting){
+                                $timeout(ping_until_success, 1000)
+                            }
+                        }
+                    });
+                }
+
+                $scope.async_waiting = true;
+                $http.post(
+                    '/search/extract/download',
+                    {criteria: JSON.stringify($scope.criteria)}
+                ).then(function(result){
+                    $scope.extract_id = result.data.extract_id;
+                    ping_until_success();
                 });
             }
 
-            $scope.async_waiting = true;
-            $http.post(
-                '/search/extract/download',
-                {criteria: JSON.stringify($scope.criteria)}
-            ).then(function(result){
-                $scope.extract_id = result.data.extract_id;
-                ping_until_success();
-            });
-        }
+            $scope.jumpToFilter = function($event, filter){
+                $event.preventDefault()
+                $scope.criteria = filter.criteria;
+            }
 
-        $scope.jumpToFilter = function($event, filter){
-            $event.preventDefault()
-            $scope.criteria = filter.criteria;
-        }
+            $scope.editFilter = function($event, filter, $index){
+                $event.preventDefault();
+		        modal = $modal.open({
+			        templateUrl: '/search/templates/modals/save_filter_modal.html/',
+			        controller: 'SaveFilterCtrl',
+			        resolve: {
+				        params: function() { return $scope.filters[$index]; }
+			        }
+		        }).result.then(function(result){
+                    $scope.filters[$index] = result;
+                });
+            }
 
-        $scope.editFilter = function($event, filter, $index){
-            $event.preventDefault();
-		    modal = $modal.open({
-			    templateUrl: '/search/templates/modals/save_filter_modal.html/',
-			    controller: 'SaveFilterCtrl',
-			    resolve: {
-				    params: function() { return $scope.filters[$index]; }
-			    }
-		    }).result.then(function(result){
-                $scope.filters[$index] = result;
-            });
-        }
+            $scope.save = function(){
 
-        $scope.save = function(){
+		        modal = $modal.open({
+			        templateUrl: '/search/templates/modals/save_filter_modal.html/',
+			        controller: 'SaveFilterCtrl',
+			        resolve: {
+				        params: function() { return {name: null, criteria: $scope.completeCriteria()}; }
+			        }
+		        }).result.then(function(result){
+                    $scope.filters.push(result);
+                });
+            };
 
-		    modal = $modal.open({
-			    templateUrl: '/search/templates/modals/save_filter_modal.html/',
-			    controller: 'SaveFilterCtrl',
-			    resolve: {
-				    params: function() { return {name: null, criteria: $scope.completeCriteria()}; }
-			    }
-		    }).result.then(function(result){
-                $scope.filters.push(result);
-            });
-        };
+            $scope.jumpToEpisode = function(episode){
+                window.open('#/episode/'+episode.id, '_blank');
+            }
 
-        $scope.jumpToEpisode = function(episode){
-            window.open('#/episode/'+episode.id, '_blank');
-        }
-
-    });
+        });
+    })

--- a/opal/static/js/opal/controllers/add_episode.js
+++ b/opal/static/js/opal/controllers/add_episode.js
@@ -1,48 +1,52 @@
 angular.module('opal.controllers')
-    .controller('AddEpisodeCtrl', function($scope, $http,
-                                           $timeout, $routeParams,
-                                           $modalInstance, $rootScope,
-                                           Episode,
-                                           FieldTranslater,
-                                           TagService,
-                                           options,
-                                           demographics,
-                                           tags) {
-        var currentTags = [];
+    .controller(
+        'AddEpisodeCtrl',
+        function($scope, $http,
+                 $timeout, $routeParams,
+                 $modalInstance, $rootScope,
+                 Episode, FieldTranslater, Referencedata,
+                 TagService,
+                 options,
+                 demographics,
+                 tags){
+            "use strict";
+            Referencedata.then(function(referencedata){
 
-	    for (var name in options) {
-		    $scope[name + '_list'] = options[name];
-	    };
+                var currentTags = [];
 
-	    $scope.editing = {
-            tagging: [{}],
-		    location: {},
-            demographics: demographics
-	    };
+                _.extend($scope, referencedata.toLookuplists());
 
-        if(tags.tag){
-            currentTags = [tags.tag];
-        }
+	            $scope.editing = {
+                    tagging: [{}],
+		            location: {},
+                    demographics: demographics
+	            };
 
-        if(tags.subtag){
-            // if there's a subtag, don't tag with the parent tag
-            currentTags = [tags.subtag];
-        }
+                if(tags.tag){
+                    currentTags = [tags.tag];
+                }
 
-        $scope.tagService = new TagService(currentTags);
+                if(tags.subtag){
+                    // if there's a subtag, don't tag with the parent tag
+                    currentTags = [tags.subtag];
+                }
 
-	    $scope.save = function() {
-            $scope.editing.tagging = [$scope.tagService.toSave()];
-            var toSave = FieldTranslater.jsToPatient($scope.editing)
+                $scope.tagService = new TagService(currentTags);
 
-		    $http.post('/api/v0.1/episode/', toSave).success(function(episode) {
-			    episode = new Episode(episode);
-			    $modalInstance.close(episode);
-		    });
-	    };
+	            $scope.save = function() {
+                    $scope.editing.tagging = [$scope.tagService.toSave()];
+                    var toSave = FieldTranslater.jsToPatient($scope.editing)
 
-	    $scope.cancel = function() {
-		    $modalInstance.close(null);
-	    };
+		            $http.post('/api/v0.1/episode/', toSave).success(function(episode) {
+			            episode = new Episode(episode);
+			            $modalInstance.close(episode);
+		            });
+	            };
 
-    });
+	            $scope.cancel = function() {
+		            $modalInstance.close(null);
+	            };
+
+            });
+
+        });

--- a/opal/static/js/opal/controllers/edit_item.js
+++ b/opal/static/js/opal/controllers/edit_item.js
@@ -2,147 +2,145 @@ angular.module('opal.controllers').controller(
     'EditItemCtrl', function($scope, $cookieStore, $timeout,
                              $modalInstance, $modal, $q,
                              ngProgressLite,
+                             Referencedata,
                              profile, item, options, episode) {
+        Referencedata.then(function(referencedata){
+            $scope.profile = profile;
+            $scope.the_episode = episode;
+            $scope.episode = episode.makeCopy();
+            // Some fields should only be shown for certain categories.
+            // Make that category available to the template.
+            $scope.episode_category = episode.category;
+            $scope.editing = {};
+            $scope.editing[item.columnName] = item.makeCopy();
 
-        $scope.profile = profile;
-        $scope.the_episode = episode;
-        $scope.episode = episode.makeCopy();
-        // Some fields should only be shown for certain categories.
-        // Make that category available to the template.
-        $scope.episode_category = episode.category;
-        $scope.editing = {};
-        $scope.editing[item.columnName] = item.makeCopy();
+            $scope.editingMode = function(){
+                return !_.isUndefined($scope.editing[item.columnName].id);
+            };
 
-        $scope.editingMode = function(){
-            return !_.isUndefined($scope.editing[item.columnName].id);
-        };
+            // This is the patientname displayed in the modal header
+  	        $scope.editingName = item.episode.demographics[0].first_name + ' ' + episode.demographics[0].surname;
 
-        // This is the patientname displayed in the modal header
-  	    $scope.editingName = item.episode.demographics[0].first_name + ' ' + episode.demographics[0].surname;
+            $scope.columnName = item.columnName;
+            _.extend($scope, referencedata.toLookuplists());
 
-        $scope.columnName = item.columnName;
+            $scope.macros = options.macros;
+            $scope.select_macro = function(item){
+                return item.expanded;
+            };
 
-  	    for (var name in options) {
-  		    if (name.indexOf('micro_test') != 0) {
-  			    $scope[name + '_list'] = _.uniq(options[name]);
-  		    };
-  	    };
+            // TODO - don't hardcode this
+	        if (item.columnName == 'microbiology_test' || item.columnName == 'lab_test' || item.columnName == 'investigation') {
+		        $scope.microbiology_test_list = [];
+		        $scope.microbiology_test_lookup = {};
+		        $scope.micro_test_defaults =  options.micro_test_defaults;
 
-        $scope.macros = options.macros;
-        $scope.select_macro = function(item){
-            return item.expanded;
-        };
+		        for (var name in options){
+			        if (name.indexOf('micro_test') == 0) {
+				        for (var ix = 0; ix < options[name].length; ix++) {
+					        $scope.microbiology_test_list.push(options[name][ix]);
+					        $scope.microbiology_test_lookup[options[name][ix]] = name;
+				        };
+			        };
+		        };
+                var watchName = "editing." + item.columnName + ".test"
+		        $scope.$watch(watchName, function(testName) {
 
-        // TODO - don't hardcode this
-	    if (item.columnName == 'microbiology_test' || item.columnName == 'lab_test' || item.columnName == 'investigation') {
-		    $scope.microbiology_test_list = [];
-		    $scope.microbiology_test_lookup = {};
-		    $scope.micro_test_defaults =  options.micro_test_defaults;
+                    _.each(_.keys($scope.editing[item.columnName]), function(field){
+                        if(field !== "test" && field !== "date_ordered" && field !== "id" && field !== "episode_id" && field !== "consistency_token"){
+                            $scope.editing[item.columnName][field] = undefined;
+                        }
+                    });
 
-		    for (var name in options){
-			    if (name.indexOf('micro_test') == 0) {
-				    for (var ix = 0; ix < options[name].length; ix++) {
-					    $scope.microbiology_test_list.push(options[name][ix]);
-					    $scope.microbiology_test_lookup[options[name][ix]] = name;
-				    };
-			    };
-		    };
-        var watchName = "editing." + item.columnName + ".test"
-		    $scope.$watch(watchName, function(testName) {
-
-          _.each(_.keys($scope.editing[item.columnName]), function(field){
-              if(field !== "test" && field !== "date_ordered" && field !== "id" && field !== "episode_id" && field !== "consistency_token"){
-                $scope.editing[item.columnName][field] = undefined;
-              }
-          });
-
-			    $scope.testType = $scope.microbiology_test_lookup[testName];
-          if( _.isUndefined(testName) || _.isUndefined($scope.testType) ){
-              return;
-          }
-
-          if($scope.testType in $scope.micro_test_defaults){
-            _.each(_.pairs($scope.micro_test_defaults[$scope.testType]), function(values){
-                    var field =  values[0];
-                    var val =  values[1];
-                    $scope.editing[item.columnName][field] = val;
-            });
-          }
-		    });
-	    };
-
-	    $scope.episode_category_list = ['Inpatient', 'Outpatient', 'Review'];
-
-        $scope.delete = function(result){
-            $modalInstance.close(result);
-            var modal = $modal.open({
-                templateUrl: '/templates/modals/delete_item_confirmation.html/',
-                controller: 'DeleteItemConfirmationCtrl',
-                size: 'lg',
-                resolve: {
-                    item: function() {
-                        return item;
+			        $scope.testType = $scope.microbiology_test_lookup[testName];
+                    if( _.isUndefined(testName) || _.isUndefined($scope.testType) ){
+                        return;
                     }
+
+                    if($scope.testType in $scope.micro_test_defaults){
+                        _.each(_.pairs($scope.micro_test_defaults[$scope.testType]), function(values){
+                            var field =  values[0];
+                            var val =  values[1];
+                            $scope.editing[item.columnName][field] = val;
+                        });
+                    }
+		        });
+	        };
+
+	        $scope.episode_category_list = ['Inpatient', 'Outpatient', 'Review'];
+
+            $scope.delete = function(result){
+                $modalInstance.close(result);
+                var modal = $modal.open({
+                    templateUrl: '/templates/modals/delete_item_confirmation.html/',
+                    controller: 'DeleteItemConfirmationCtrl',
+                    size: 'lg',
+                    resolve: {
+                        item: function() {
+                            return item;
+                        }
+                    }
+                });
+            };
+
+            //
+            // Save the item that we're editing.
+            //
+
+            $scope.saving = false;
+
+            $scope.preSave = function(editing){};
+
+	        $scope.save = function(result) {
+                $scope.saving = true;
+                ngProgressLite.set(0);
+                ngProgressLite.start();
+                $scope.preSave($scope.editing);
+
+                to_save = [item.save($scope.editing[item.columnName])];
+                if(!angular.equals($scope.the_episode.makeCopy(), $scope.episode)){
+                    to_save.push($scope.the_episode.save($scope.episode));
                 }
-            });
-        };
 
-        //
-        // Save the item that we're editing.
-        //
-
-      $scope.saving = false;
-
-      $scope.preSave = function(editing){};
-
-	    $scope.save = function(result) {
-            $scope.saving = true;
-            ngProgressLite.set(0);
-            ngProgressLite.start();
-            $scope.preSave($scope.editing);
-
-            to_save = [item.save($scope.editing[item.columnName])];
-            if(!angular.equals($scope.the_episode.makeCopy(), $scope.episode)){
-                to_save.push($scope.the_episode.save($scope.episode));
-            }
-
-            $q.all(to_save).then(function() {
-                $scope.saving = false;
-                ngProgressLite.done();
+                $q.all(to_save).then(function() {
+                    $scope.saving = false;
+                    ngProgressLite.done();
       			    $modalInstance.close(result);
-		    });
+		        });
 
-	    };
+	        };
 
-        // Let's have a nice way to kill the modal.
-	    $scope.cancel = function() {
-		    $modalInstance.close('cancel');
-	    };
+            // Let's have a nice way to kill the modal.
+	        $scope.cancel = function() {
+		        $modalInstance.close('cancel');
+	        };
 
-        $scope.undischarge = function() {
-            undischargeMoadal = $modal.open({
-                templateUrl: '/templates/modals/undischarge.html/',
-                controller: 'UndischargeCtrl',
-                resolve: {episode: function(){ return episode } }
-            }
-            ).result.then(function(result){
-                $modalInstance.close(episode.location[0])
-            });
-        };
-
-        $scope.prepopulate = function($event) {
-            $event.preventDefault();
-            var data = $($event.target).data()
-            _.each(_.keys(data), function(key){
-                if(data[key] == 'true'){
-                    data[key] = true;
-                    return
+            $scope.undischarge = function() {
+                undischargeMoadal = $modal.open({
+                    templateUrl: '/templates/modals/undischarge.html/',
+                    controller: 'UndischargeCtrl',
+                    resolve: {episode: function(){ return episode } }
                 }
-                if(data[key] == 'false'){
-                    data[key] = false;
-                    return
-                }
-            });
-            angular.extend($scope.editing[item.columnName], data);
-        };
+                                               ).result.then(function(result){
+                                                   $modalInstance.close(episode.location[0])
+                                               });
+            };
+
+            $scope.prepopulate = function($event) {
+                $event.preventDefault();
+                var data = $($event.target).data()
+                _.each(_.keys(data), function(key){
+                    if(data[key] == 'true'){
+                        data[key] = true;
+                        return
+                    }
+                    if(data[key] == 'false'){
+                        data[key] = false;
+                        return
+                    }
+                });
+                angular.extend($scope.editing[item.columnName], data);
+            };
+
+        });
     });

--- a/opal/static/js/opal/services/referencedata.js
+++ b/opal/static/js/opal/services/referencedata.js
@@ -7,12 +7,31 @@ angular.module('opal.services').factory('Referencedata', function($q, $http, $wi
     var Referencedata = function(data){
         var self = this;
 
+        var lists = _.keys(data);
+
+        self.initialize = function(){
+            _.extend(self, data)
+        }
+
         self.get = function(what){
             return self[what];
         }
 
-        self.initialize = function(){
-            _.extend(self, data)
+        //
+        // For reasons that can only be termed 'legacy', many parts of the
+        // OPAL ecosystem expect reference data to be available from lookup
+        // lists with the _list suffix.
+        //
+        // We use this function here to move the code that generates them
+        // into one place - as this logic was replicated at in least 15 places
+        // at the time of writing.
+        //
+        self.toLookuplists = function(){
+            var lookuplists = {};
+            _.each(lists, function(list_name){
+                lookuplists[list_name + '_list'] = self[list_name];
+            });
+            return lookuplists;
         }
 
         self.initialize();

--- a/opal/static/js/opal/services/referencedata.js
+++ b/opal/static/js/opal/services/referencedata.js
@@ -1,4 +1,5 @@
 angular.module('opal.services').factory('Referencedata', function($q, $http, $window) {
+
     "use strict";
 
     var deferred = $q.defer();

--- a/opal/static/js/opaltest/add_episode.controller.test.js
+++ b/opal/static/js/opaltest/add_episode.controller.test.js
@@ -37,6 +37,12 @@ describe('AddEpisodeCtrl', function (){
         tag_hierarchy :{'tropical': []}
     };
 
+    var referencedata = {
+        dogs: ['Poodle', 'Dalmation'],
+        hats: ['Bowler', 'Top', 'Sun']
+    };
+
+
     beforeEach(function(){
         module('opal');
         var $controller, $modal
@@ -58,6 +64,8 @@ describe('AddEpisodeCtrl', function (){
 
         schema = new Schema(columns.default);
         modalInstance = $modal.open({template: 'Notatemplate'});
+        $scope = $rootScope.$new();
+
         var controller = $controller('AddEpisodeCtrl', {
             $scope: $scope,
             $modalInstance: modalInstance,
@@ -67,6 +75,12 @@ describe('AddEpisodeCtrl', function (){
             demographics: {},
             tags: {tag: 'tropical', subtag: ''}
         });
+
+        $httpBackend.expectGET('/api/v0.1/userprofile/').respond({});
+        $httpBackend.expectGET('/api/v0.1/referencedata/').respond(referencedata);
+        $scope.$apply();
+        $httpBackend.flush();
+
     });
 
     describe('initial state', function() {
@@ -78,7 +92,6 @@ describe('AddEpisodeCtrl', function (){
     describe('save()', function(){
 
         it('should save', function(){
-            $httpBackend.expectGET('/api/v0.1/userprofile/').respond({});
             $httpBackend.expectPOST('/api/v0.1/episode/').respond({demographics:[{patient_id: 1}]})
             $scope.editing.date_of_admission = moment(new Date(13, 1, 2014));
             $scope.editing.demographics.date_of_birth = moment(new Date(13, 1, 1914));

--- a/opal/static/js/opaltest/edit_item.controller.test.js
+++ b/opal/static/js/opaltest/edit_item.controller.test.js
@@ -1,9 +1,15 @@
 describe('EditItemCtrl', function (){
     "use strict";
 
-    var $scope, $cookieStore, $timeout, $modal, item, Item;
+    var $scope, $cookieStore, $timeout, $modal, $httpBackend;
+    var item, Item;
     var dialog, Episode, episode, ngProgressLite, $q, $rootScope;
     var Schema, $controller, controller, fakeModalInstance;
+
+    var referencedata = {
+        dogs: ['Poodle', 'Dalmation'],
+        hats: ['Bowler', 'Top', 'Sun']
+    };
 
     var episodeData = {
         id: 123,
@@ -88,13 +94,13 @@ describe('EditItemCtrl', function (){
             "Stool Parasitology PCR"
         ],
         micro_test_defaults: {
-          micro_test_c_difficile: {
-            c_difficile_antigen: "pending",
-            c_difficile_toxin: "pending"
-          }
+            micro_test_c_difficile: {
+                c_difficile_antigen: "pending",
+                c_difficile_toxin: "pending"
+            }
         },
         micro_test_c_difficile: [
-          "C diff", "Clostridium difficile"
+            "C diff", "Clostridium difficile"
         ]
     };
 
@@ -116,6 +122,7 @@ describe('EditItemCtrl', function (){
             Episode        = $injector.get('Episode');
             $controller    = $injector.get('$controller');
             $q             = $injector.get('$q');
+            $httpBackend   = $injector.get('$httpBackend');
             $cookieStore   = $injector.get('$cookieStore');
             $timeout       = $injector.get('$timeout');
             $modal         = $injector.get('$modal');
@@ -152,6 +159,10 @@ describe('EditItemCtrl', function (){
             episode       : episode,
             ngProgressLite: ngProgressLite,
         });
+
+        $httpBackend.expectGET('/api/v0.1/referencedata/').respond(referencedata);
+        $scope.$apply();
+        $httpBackend.flush();
 
     });
 
@@ -258,32 +269,35 @@ describe('EditItemCtrl', function (){
 
     describe('testType', function(){
         beforeEach(function(){
-          var existingEpisode = new Episode(angular.copy(episodeData));
+            var existingEpisode = new Episode(angular.copy(episodeData));
 
-          // when we prepopulate we should not remove the consistency_token
-          existingEpisode.microbiology_test = [{
-            test: "T brucei Serology",
-            consistency_token: "23423223"
-          }];
+            // when we prepopulate we should not remove the consistency_token
+            existingEpisode.microbiology_test = [{
+                test: "T brucei Serology",
+                consistency_token: "23423223"
+            }];
 
-          item = new Item(
-              existingEpisode.microbiology_test[0],
-              existingEpisode,
-              columns['default'][4]
-          );
+            item = new Item(
+                existingEpisode.microbiology_test[0],
+                existingEpisode,
+                columns['default'][4]
+            );
 
-          $scope = $rootScope.$new();
-          controller = $controller('EditItemCtrl', {
-              $scope        : $scope,
-              $cookieStore  : $cookieStore,
-              $timeout      : $timeout,
-              $modalInstance: fakeModalInstance,
-              item          : item,
-              options       : options,
-              profile       : profile,
-              episode       : existingEpisode,
-              ngProgressLite: ngProgressLite,
-          });
+            $scope = $rootScope.$new();
+            controller = $controller('EditItemCtrl', {
+                $scope        : $scope,
+                $cookieStore  : $cookieStore,
+                $timeout      : $timeout,
+                $modalInstance: fakeModalInstance,
+                item          : item,
+                options       : options,
+                profile       : profile,
+                episode       : existingEpisode,
+                ngProgressLite: ngProgressLite,
+            });
+            // We need to fire the promise - the http expectation is set above.
+            $scope.$apply();
+
         })
 
         it('should prepopulate microbiology tests', function(){

--- a/opal/static/js/opaltest/extract.controller.test.js
+++ b/opal/static/js/opaltest/extract.controller.test.js
@@ -8,6 +8,10 @@ describe('ExtractCtrl', function(){
         condition: ['Another condition', 'Some condition'],
         tag_hierarchy :{'tropical': []}
     }
+    var referencedata = {
+        dogs: ['Poodle', 'Dalmation'],
+        hats: ['Bowler', 'Top', 'Sun']
+    };
 
     var columnsData = [
         {
@@ -118,6 +122,12 @@ describe('ExtractCtrl', function(){
             schema : schema,
             PatientSummary: PatientSummary
         });
+
+        $httpBackend.expectGET('/api/v0.1/userprofile/').respond({roles: {default: []}});
+        $httpBackend.expectGET('/api/v0.1/referencedata/').respond(referencedata);
+        $scope.$apply();
+        $httpBackend.flush();
+
     });
 
     describe('Getting Complete Criteria', function(){
@@ -283,9 +293,6 @@ describe('ExtractCtrl', function(){
     });
 
     describe('Search', function(){
-        beforeEach(function(){
-            $httpBackend.expectGET('/api/v0.1/userprofile/').respond({roles: {default: []}});
-        });
 
         it('should ask the server for results', function(){
             $httpBackend.expectPOST("/search/extract/").respond({
@@ -340,7 +347,6 @@ describe('ExtractCtrl', function(){
         });
 
         it('should post to the url', function() {
-            $httpBackend.expectGET('/api/v0.1/userprofile/').respond({});
             $httpBackend.expectPOST('/search/extract/download').respond({extract_id: '23'});
             $httpBackend.expectGET('/search/extract/result/23').respond({state: 'SUCCESS'})
             $scope.async_extract();
@@ -355,7 +361,6 @@ describe('ExtractCtrl', function(){
         });
 
         it('should re-ping', function() {
-            $httpBackend.expectGET('/api/v0.1/userprofile/').respond({});
             $httpBackend.expectPOST('/search/extract/download').respond({});
             $scope.async_extract();
             $timeout.flush()
@@ -365,7 +370,6 @@ describe('ExtractCtrl', function(){
         });
 
         it('should alert if we fail', function() {
-            $httpBackend.expectGET('/api/v0.1/userprofile/').respond({});
             $httpBackend.expectPOST('/search/extract/download').respond({extract_id: '23'});
             $httpBackend.expectGET('/search/extract/result/23').respond({state: 'FAILURE'})
             spyOn($window, 'alert');

--- a/opal/static/js/opaltest/referencedata.service.test.js
+++ b/opal/static/js/opaltest/referencedata.service.test.js
@@ -4,7 +4,7 @@ describe('Referencedata', function(){
     var $httpBackend, $rootScope;
     var mock, Referencedata;
     var referencedata = {
-        foo: 'bar'
+        foo: ['bar']
     };
 
     beforeEach(function(){
@@ -35,7 +35,7 @@ describe('Referencedata', function(){
         $rootScope.$apply();
         $httpBackend.flush();
 
-        expect(result.get('foo')).toEqual('bar');
+        expect(result.get('foo')).toEqual(['bar']);
     });
 
     it('should alert if the HTTP request errors', function(){
@@ -48,4 +48,18 @@ describe('Referencedata', function(){
 
         expect(mock.alert).toHaveBeenCalledWith('Referencedata could not be loaded');
     });
+
+    it('should return with the _list suffix', function(){
+        var result
+
+        $httpBackend.whenGET('/api/v0.1/referencedata/').respond(referencedata);
+
+        Referencedata.then(function(r){ result = r; });
+        $rootScope.$apply();
+        $httpBackend.flush();
+
+        expect(result.toLookuplists()).toEqual({foo_list: ['bar']})
+
+    })
+
 });


### PR DESCRIPTION
Starts to use Referencedata.

Some of these diffs are unpleasant because adding the promise at the top of the controller requires re-indenting the whole file.

Do we have a better way to do this ? e.g. to force the HTTP request to have resolved itself by the time you inject into the controller ?

(If so, point me at it, and this should probably include a refactor of Referencedata to do it that way ! )