### PR TITLE
Remove clone()

### DIFF
--- a/opal/static/js/opal/utils.js
+++ b/opal/static/js/opal/utils.js
@@ -176,13 +176,6 @@ if (!Array.prototype.indexOf) {
 	Array.prototype.indexOf = _indexof
 }
 
-function clone(obj) {
-	if (typeof obj == 'object') {
-		return $.extend(true, {}, obj);
-	} else {
-		return obj;
-	}
-};
 
 // From http://stackoverflow.com/a/3937924/2463201
 jQuery.support.placeholder = (function(){


### PR DESCRIPTION
This was used a long time back - essentially in place of what `Item.makeCopy()` does now. We don't use it anywhere any more - and should almost certainly just use the Underscore equivalent in the name of not having to maintain it ! 