### PR TITLE
803 collectstatic from scaffold app

### DIFF
--- a/bin/opal
+++ b/bin/opal
@@ -128,15 +128,24 @@ def startproject(args):
     nix.mv(project_dir/'app', app_dir)
 
     # 7. Create extra directories we need
-    js = app_dir/'assets/js/{0}'.format(name)
-    css = app_dir/'assets/css'
+    js = app_dir/'static/js/{0}'.format(name)
+    css = app_dir/'static/css'
     js.mkdir()
     css.mkdir()
-    nix.mv(app_dir/'static/js/app/routes.js', app_dir/'assets/js/{0}/routes.js'.format(name))
-    nix.rm_r(app_dir/'static')
+    nix.mv(app_dir/'static/js/app/routes.js', app_dir/'static/js/{0}/routes.js'.format(name))
 
     templates = app_dir/'templates'/name
     templates.mkdir()
+
+    assets = app_dir/'assets'
+    assets.mkdir()
+    assets_explainer = assets/'README.md'
+    assets_explainer << """
+    This placeholder file is here to ensure that there we still have our STATICFILES_DIRS target
+    if we commit generated code to source control.
+
+    This means that we can run collectstatic OK.
+    """
 
     # We have this here because it uses name from above.
     def manage(command):

--- a/opal/scaffolding/scaffold/gitignore
+++ b/opal/scaffolding/scaffold/gitignore
@@ -1,7 +1,13 @@
 *~
 *.sqlite
 *.pyc
-static/*
+*/assets/js/*
+*/assets/css/*
+*/assets/img/*
+*/assets/admin/*
+*/assets/rest_framework/*
+*/assets/bootstrap*
+*/assets/CACHE/*
 .coverage
 htmlcov
 libpeerconnection.log

--- a/opal/scaffolding/scaffold/requirements.txt
+++ b/opal/scaffolding/scaffold/requirements.txt
@@ -1,6 +1,6 @@
 # cryptography is required for heroku deployment
 cryptography==1.3.2
-Django==1.8.3
+Django==1.8.13
 coverage==3.6
 dj-database-url==0.2.1
 gunicorn==0.17.4
@@ -15,4 +15,7 @@ requests==2.7.0
 djangorestframework==3.2.2
 django-compressor==1.5
 supervisor==3.0
--e git://github.com/openhealthcare/opal.git@master#egg=opal
+python-dateutil==2.4.2
+django-celery==3.1.17
+celery==3.1.19
+opal==0.7.0


### PR DESCRIPTION
This addresses the collectstatic issue raises in #803 by ensuring that the relevant directory exists and will be added by a naive `git add .` but the assets pulled by collectstatic will not by default.

In testing this fix with deployment to some throwaway Heroku apps, also discovered that the requirements.txt in the scaffold app was out of date so have updated this also.

https://peaceful-savannah-91543.herokuapp.com/ is serving basically `opal startproject newapp` with `DEBUG=False` using dj-static.