### PR TITLE
Code should never really use opal.core.application.OpalApplication unless we're subclassing it

### DIFF
--- a/opal/templatetags/plugins.py
+++ b/opal/templatetags/plugins.py
@@ -65,7 +65,7 @@ def plugin_opal_angular_deps():
 @register.inclusion_tag('plugins/angular_exclude_tracking.html')
 def plugin_opal_angular_tracking_exclude():
     def yield_property(property_name):
-        app = application.OpalApplication
+        app = application.get_app()
         app_and_plugins = itertools.chain(plugins.plugins(), [app])
 
         for plugin in app_and_plugins:


### PR DESCRIPTION
We should use opal.core.application.get_app() here to allow user applications to override this.