### PR TITLE
Remove an old internal API utility function

### DIFF
--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -191,16 +191,6 @@ class SubrecordViewSet(viewsets.ViewSet):
     This is the base viewset for our subrecords.
     """
 
-    def _item_to_dict(self, item, user):
-        """
-        Given an item, serialize either the patient or episode it is a
-        subrecord of.
-        """
-        try:
-            return item.episode.to_dict(user)
-        except AttributeError:
-            return item.patient.to_dict(user)
-
     def create(self, request):
         """
         * Create a subrecord


### PR DESCRIPTION
AFAICT his this was only used for the old pre, post Gloss / Cedar integration serialization.