### PR TITLE
Remove duplicate datetime clause from OPALSerializer

### DIFF
--- a/opal/core/views.py
+++ b/opal/core/views.py
@@ -30,12 +30,6 @@ class OpalSerializer(DjangoJSONEncoder):
                     o, datetime.datetime.min.time()
                 ), settings.DATE_FORMAT
             )
-        elif isinstance(o, datetime.datetime):
-            return format(
-                datetime.datetime.combine(
-                    o, datetime.datetime.min.time()
-                ), settings.DATETIME_FORMAT
-            )
         super(OpalSerializer, self).default(o)
 
 


### PR DESCRIPTION
If you look slightly above this section, it is impossible to reach it. The Gloss serializer doesn't have this clause...