### PR TITLE
Kill legacy gloss apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.0 (Major Release)
 
 Removes `Options` both from the JSON API, and the Angular service.
+Removes legacy APIs `/api/v0.1/episode/admit` and `/api/v0.1/episode/refer`.
 
 ### 0.7.1 (Minor Release)
 

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -346,35 +346,6 @@ def register_plugin_apis():
 
 register_plugin_apis()
 
-class APIAdmitEpisodeView(View):
-    """
-    Admit an episode from upstream!
-    """
-    def post(self, *args, **kwargs):
-        data = _get_request_data(self.request)
-        resp = {'ok': 'Got your admission just fine - thanks!'}
-        return _build_json_response(resp)
-
-
-class APIReferPatientView(View):
-    """
-    Refer a patient
-    """
-    # TODO - explore when this is used - seems like there should be a better way?
-    def post(self, *args, **kwargs):
-        """
-        Expects PATIENT, EPISODE, TARGET
-        """
-        data = _get_request_data(self.request)
-        episode = Episode.objects.get(pk=data['episode'])
-        current_tags = episode.get_tag_names(None)
-        if not data['target'] in current_tags:
-            current_tags.append(data['target'])
-            episode.set_tag_names(current_tags, None)
-        resp = {'ok': 'Got your referral just fine - thanks!'}
-        return _build_json_response(resp)
-
-
 class EpisodeListApi(View):
     """
     Return serialised subsets of active episodes by tag.

--- a/opal/urls.py
+++ b/opal/urls.py
@@ -52,8 +52,6 @@ urlpatterns = patterns(
         views.DeleteItemConfirmationView.as_view()),
 
     # New Public facing API urls
-    url(r'api/v0.1/episode/admit', csrf_exempt(api.APIAdmitEpisodeView.as_view())),
-    url(r'api/v0.1/episode/refer', csrf_exempt(api.APIReferPatientView.as_view())),
     url(r'api/v0.1/', include(api.router.urls)),
     url(r'^templates/record/(?P<model>[a-z_\-]+).html$',
         views.RecordTemplateView.as_view(), name="record_view"),


### PR DESCRIPTION
These were originally added as part of some exploratory integration work with early versions of Gloss/Cedar - this never really went anywhere, and we now have more robust APIs for both of these things.

The Admit view literally does nothing other than send you a success message (Which is stupid).

The Refer view does do something, but was only ever used by an old Cedar call which would now never use this API (Because steps run with full access to the internal Opal Python API).

