### PR TITLE
Nice idea, but we don't have this case

### DIFF
--- a/opal/static/js/opal/services/record_editor.js
+++ b/opal/static/js/opal/services/record_editor.js
@@ -100,10 +100,6 @@ angular.module('opal.services').factory('RecordEditor', function(
     };
 
     self.newItem = function(name){
-      if (!episode[name]) {
-          episode[name] = [];
-      }
-
       var iix = episode[name].length;
       var item = self.getItem(name, iix);
 


### PR DESCRIPTION
Note that for the rest of this code path to work, the `/record/` definition needs to be on `$rootScope`.
Because https://github.com/openhealthcare/opal/blob/v0.8.0/opal/static/js/opal/services/episode.js#L27 if it was there, we'd have an empty array.

Note also the fact that the explicit test for creating a new item that didn't exist doesn't hit this code path: https://coveralls.io/builds/7705961/source?filename=opal%2Fstatic%2Fjs%2Fopal%2Fservices%2Frecord_editor.js#L104