### PR TITLE
form name is now form by default. This means that things just work in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,22 @@ Removes the `static` argument from the forms `input` tag. Developers should move
 
 Look up lists now load in from individual apps. The look for a file at {{ app }}/data/lookuplists.json
 
+Adds the checkForm directive
+
+e.g.
+
+```html
+<button check-form="form" ng-click="sendDataToTheServer">click me</button>
+```
+
+This adds default form submission behaviour to the a button. It will check if the form is valid, and if its not it will mark the button as disabled until it becomes valid.
+
+It will also set the form as submitted.
+
+We also now show the required error if the form has been submitted or if the field is dirty, so that the user doesn't get an ugly "fill this field in now" message when
+opening the modal/pathway but will get the error after they click submit.
+
+
 #### Updates to the Dependency Graph
 
 Upgrades angular to v1.5.8 (from 1.3.11) you can see their change log [here](https://github.com/angular/angular.js/blob/master/CHANGELOG.md)

--- a/doc/docs/reference/javascript_helpers.md
+++ b/doc/docs/reference/javascript_helpers.md
@@ -47,6 +47,26 @@ A directive that if set with no arguments, or set to true, will only allow a but
 clicked on once and then it'll be disabled. Useful for example to make sure that multiple save requests aren't
 accidentally triggered.
 
+#### check-form
+
+Similar to one click only but it takes the form in use as an argument
+
+e.g.
+```html
+<button check-form="form" ng-click="sendDataToTheServer">click me</button>
+```
+
+This checks the form for valid on click.
+
+If the form is then not valid. It will not call the second function, but mark the form as submitted and disable the button.
+
+It will watch for the form to become valid and undisable the button when that happens.
+
+If the form is valid, it will allow the ng-click function to be called.
+
+This means that if you only want to show error messages after the user has clicked the save button you can do so with the
+form.$submitted variable.
+
 #### scroll-top
 
 Adds a click handler to the element that when click will animate the body of the element to scroll to the top

--- a/opal/static/css/opal.css
+++ b/opal/static/css/opal.css
@@ -490,7 +490,7 @@ table { font-size: 12px; }
 
 .table.search tbody tr td { padding: 8px; }
 
-input.ng-invalid.ng-dirty { background-color : #fcc; }
+input.ng-invalid.ng-dirty, .ng-submitted input.ng-invalid-required{ background-color : #fcc; }
 
 .errored-state input, .errored-state .ui-select-toggle, .errored-state .ui-select-multiple{
     background-color: #fcc;

--- a/opal/static/js/opal/directives.js
+++ b/opal/static/js/opal/directives.js
@@ -290,7 +290,7 @@ directives.directive('checkForm', function(){
               $element.prop( "disabled", false);
             }
             else if(_.size(scope.checkForm.$error) && scope.checkForm.$submitted){
-              $element.prop( "disabled", true);
+            $element.prop( "disabled", true);
             }
         });
       });

--- a/opal/static/js/opal/directives.js
+++ b/opal/static/js/opal/directives.js
@@ -261,6 +261,44 @@ directives.directive('oneClickOnly', function(){
   };
 });
 
+directives.directive('checkForm', function(){
+  // if the form has errors,
+  //    set the submitted flag
+  //    disable the button
+  //    if the errors are fixed,
+  //        undisable the button
+  // else
+  //     mirror the one click only behaviour
+  return {
+    scope: {
+      checkForm: "=",
+    },
+    link: function(scope, $element){
+      var hadError = false;
+      $element.on('click', function(){
+        if(!scope.checkForm.$valid){
+          if(!$element.prop('disabled')){
+            $element.prop( "disabled", true );
+            hadError = true;
+            scope.checkForm.$setSubmitted();
+          }
+        }
+
+        scope.$watch("checkForm.$valid", function(){
+            if(scope.checkForm.$valid && hadError){
+              hadError = false;
+              $element.prop( "disabled", false);
+            }
+            else if(_.size(scope.checkForm.$error) && scope.checkForm.$submitted){
+              $element.prop( "disabled", true);
+            }
+        });
+      });
+
+    }
+  }
+});
+
 directives.directive('clipboard', function(growl) {
     "use strict";
     // The MIT License (MIT)

--- a/opal/static/js/opaltest/directives.test.js
+++ b/opal/static/js/opaltest/directives.test.js
@@ -204,6 +204,59 @@ describe('OPAL Directives', function(){
         });
     });
 
+    describe('checkForm', function(){
+        it('should disable the button if there are errors', function(){
+            scope.editing = {something: ""};
+            var markup = '<form name="form"><input required ng-model="editing.something"><button check-form="form">Save</button></form>';
+            compileDirective(markup);
+            var btn = $(element.find("button"));
+            btn.click();
+            var innerscope = angular.element(btn).scope();
+            expect(btn.prop('disabled')).toBe(true);
+            expect(innerscope.form.$submitted).toBe(true);
+        });
+
+        it('should undisable the button if all errors are fixed', function(){
+          scope.editing = {something: ""};
+          var markup = '<form name="form"><input required ng-model="editing.something"><button check-form="form">Save</button></form>';
+          compileDirective(markup);
+          var btn = $(element.find("button"));
+          btn.click();
+          var innerscope = angular.element(btn).scope();
+          var input = $(element.find("input"));
+          expect(btn.prop('disabled')).toBe(true);
+          expect(innerscope.form.$submitted).toBe(true);
+          scope.editing.something = 'hello';
+          scope.$apply();
+          expect(btn.prop('disabled')).toBe(false);
+        });
+
+        it('should change the button to disabled if the form has been submitted', function(){
+          scope.editing = {something: ""};
+          var markup = '<form name="form"><input required ng-model="editing.something"><button check-form="form">Save</button></form>';
+          compileDirective(markup);
+          var btn = $(element.find("button"));
+          btn.click();
+          var innerscope = angular.element(btn).scope();
+          var input = $(element.find("input"));
+          expect(btn.prop('disabled')).toBe(true);
+          expect(innerscope.form.$submitted).toBe(true);
+          scope.editing.something = 'hello';
+          scope.$apply();
+          expect(btn.prop('disabled')).toBe(false);
+        });
+
+        it('should disable buttons on click and call through', function(){
+            var clickfn = jasmine.createSpy('clickfn');
+            scope.clickfn = clickfn;
+            var markup = '<button one-click-only ng-click="clickfn()">Save</button>';
+            compileDirective(markup);
+            $(element).click();
+            expect(clickfn.calls.count()).toEqual(1);
+            expect($(element).prop('disabled')).toBe(true);
+        });
+    });
+
     describe('clipboard', function(){
         var markup = '<button class="btn btn-primary" clipboard data-clipboard-target="#content">copy</button>'
         var growlSuccessSpy, growlErrorSpy, clipboardSpy;

--- a/opal/static/js/opaltest/directives.test.js
+++ b/opal/static/js/opaltest/directives.test.js
@@ -162,13 +162,22 @@ describe('OPAL Directives', function(){
       });
     });
 
+    describe('parentHeight', function(){
+        it('should be markdowny', function(){
+            var markup = '<div style="height: 200px"><div markdown="foo"></div></div>';
+            scope.editing = {foo: 'bar'}
+            compileDirective(markup);
+            expect($(element).height()).toBe(200);
+        });
+    });
+
     describe('markdown', function(){
         it('should be markdowny', function(){
             var markup = '<div markdown="foo"></div>';
             scope.editing = {foo: 'bar'}
             compileDirective(markup);
         });
-    })
+    });
 
     describe('oneClickOnly', function(){
         it('should disable buttons on click and call through', function(){

--- a/opal/static/js/opaltest/directives.test.js
+++ b/opal/static/js/opaltest/directives.test.js
@@ -207,12 +207,16 @@ describe('OPAL Directives', function(){
     describe('checkForm', function(){
         it('should disable the button if there are errors', function(){
             scope.editing = {something: ""};
-            var markup = '<form name="form"><input required ng-model="editing.something"><button check-form="form">Save</button></form>';
+            var clickfn = jasmine.createSpy('clickfn');
+            scope.clickfn = clickfn;
+
+            var markup = '<form name="form"><input required ng-model="editing.something" ng-click="clickfn()"><button check-form="form">Save</button></form>';
             compileDirective(markup);
             var btn = $(element.find("button"));
             btn.click();
             var innerscope = angular.element(btn).scope();
             expect(btn.prop('disabled')).toBe(true);
+            expect(clickfn.calls.count()).toEqual(0);
             expect(innerscope.form.$submitted).toBe(true);
         });
 

--- a/opal/static/js/opaltest/directives.test.js
+++ b/opal/static/js/opaltest/directives.test.js
@@ -177,6 +177,16 @@ describe('OPAL Directives', function(){
             scope.editing = {foo: 'bar'}
             compileDirective(markup);
         });
+    })
+
+    describe("freezeHeaders", function(){
+      it('should apply the stick table headers jquery directive', function(){
+          $.fn.stickyTableHeaders = function(){};
+          spyOn($.fn, "stickyTableHeaders");
+          var markup = '<div freeze-headers><table></tablre></div>';
+          compileDirective(markup);
+          expect($.fn.stickyTableHeaders).toHaveBeenCalled();
+      });
     });
 
     describe('oneClickOnly', function(){
@@ -216,7 +226,7 @@ describe('OPAL Directives', function(){
             btn.click();
             var innerscope = angular.element(btn).scope();
             expect(btn.prop('disabled')).toBe(true);
-            expect(clickfn.calls.count()).toEqual(0);
+            expect(clickfn).not.toHaveBeenCalled();
             expect(innerscope.form.$submitted).toBe(true);
         });
 

--- a/opal/templates/_helpers/input.html
+++ b/opal/templates/_helpers/input.html
@@ -36,12 +36,12 @@
            {% endif %}
            />
     {% if maxlength %}
-        <span class="help-block" ng-show="{{ formname }}.{{ modelname }}.$invalid && {{ formname }}.{{ modelname }}.$error.maxlength">
+        <span class="help-block" ng-show="({{ formname }}.$submitted || {{ formname }}.{{ modelname }}.$invalid) && {{ formname }}.{{ modelname }}.$error.maxlength">
           Maximum length is {{ maxlength }}
         </span>
     {% endif %}
     {% if required %}
-      <span ng-show="{{ formname }}.{{ modelname }}.$dirty && {{ formname }}.{{ modelname }}.$error.required">
+      <span class="help-block" ng-show="({{ formname }}.{{ modelname }}.$dirty || {{ formname }}.$submitted) && {{ formname }}.{{ modelname }}.$error.required">
         {{ label }} is required
       </span>
     {% endif %}

--- a/opal/templates/_helpers/input.html
+++ b/opal/templates/_helpers/input.html
@@ -36,13 +36,13 @@
            {% endif %}
            />
     {% if maxlength %}
-        <span class="help-block" ng-show="form.{{ modelname }}.$invalid">
+        <span class="help-block" ng-show="{{ formname }}.{{ modelname }}.$invalid && {{ formname }}.{{ modelname }}.$error.maxlength">
           Maximum length is {{ maxlength }}
         </span>
     {% endif %}
     {% if required %}
       <span ng-show="{{ formname }}.{{ modelname }}.$dirty && {{ formname }}.{{ modelname }}.$error.required">
-        {{ required }}
+        {{ label }} is required
       </span>
     {% endif %}
   </div>

--- a/opal/templates/_helpers/select.html
+++ b/opal/templates/_helpers/select.html
@@ -1,6 +1,6 @@
 {% load forms %}
   <div class="form-group" {% if visibility %} {{ visibility|safe }} {% endif %} >
-  <span ng-class="{ 'errored-state': {{ form_name }}.{{ model_name }}.$dirty && !{{ form_name }}.{{ model_name }}.$valid }">
+  <span ng-class="{ 'errored-state': {{ formname }}.{{ model_name }}.$dirty && !{{ formname }}.{{ model_name }}.$valid }">
   {% if label %}
   <label class="control-label col-sm-3">
     {{ label }}
@@ -24,7 +24,7 @@
       </select>
     {% endif %}
     {% if required %}
-      <span ng-show="{{ form_name }}.{{ model_name }}.$dirty && {{ form_name }}.{{ model_name }}.$error.required">
+      <span ng-show="{{ formname }}.{{ model_name }}.$dirty && {{ formname }}.{{ model_name }}.$error.required">
         {{ required }}
       </span>
     {% endif %}

--- a/opal/templates/modal_base.html
+++ b/opal/templates/modal_base.html
@@ -14,7 +14,7 @@
 </div>
 <div class="modal-body" {% block modal_body_extra %}{% endblock %}>
   {% block modal_body %}
-    <form name="form" class="form-horizontal" novalidate>
+    <form name="form" ng-submit="" class="form-horizontal" novalidate>
       {% include column.get_form_template %}
     </form>
   {% endblock %}
@@ -34,8 +34,7 @@
   {% endif %}
 
   {% block modal_save %}
-  <button one-click-only class="btn btn-primary" ng-click="save('save')"
-          ng-disabled="form.$invalid || saving">
+  <button check-form="form" class="btn btn-primary" ng-click="form.$valid && save('save')">
     <i class="fa fa-save"></i>
     Save
   </button>

--- a/opal/templatetags/forms.py
+++ b/opal/templatetags/forms.py
@@ -124,10 +124,6 @@ def _input(*args, **kwargs):
     maxlength = kwargs.pop('maxlength', None) or ctx.get("maxlength")
     datepicker = kwargs.pop("datepicker", False)
 
-    if required:
-        if not formname:
-            raise ValueError('You must pass formname if you pass required')
-
     if icon:
         icon = _icon_classes(icon)
 

--- a/opal/templatetags/forms.py
+++ b/opal/templatetags/forms.py
@@ -94,6 +94,7 @@ def extract_common_args(kwargs):
     args["modelname"] = model_name
     args["autofocus"] = kwargs.pop("autofocus", None)
     args["help_text"] = kwargs.pop("help_text", None)
+    args["formname"] = kwargs.pop('formname', 'form')
     disabled = kwargs.pop('disabled', None)
 
     if disabled:
@@ -117,7 +118,6 @@ def _input(*args, **kwargs):
 
     icon = kwargs.pop('icon', None)
     required = kwargs.pop('required', False)
-    formname = kwargs.pop('formname', None)
     unit = kwargs.pop('unit', None)
     data = kwargs.pop('data', [])
     enter = kwargs.pop('enter', None)
@@ -135,7 +135,6 @@ def _input(*args, **kwargs):
         'visibility': visibility,
         'icon'      : icon,
         'required'  : required,
-        'formname'  : formname,
         'unit'      : unit,
         'data'      : data,
         'enter'     : enter,
@@ -208,7 +207,6 @@ def select(*args, **kwargs):
     lookuplist = kwargs.pop("lookuplist", ctx.get("lookuplist", None))
     required = kwargs.pop("required", ctx.get("required", False))
 
-    form_name = kwargs.pop('formname', None)
     other = kwargs.pop('other', False)
     help_template = kwargs.pop('help', None)
     placeholder = kwargs.pop("placeholder", None)
@@ -217,10 +215,6 @@ def select(*args, **kwargs):
     default_null = kwargs.pop('default_null', True)
     tagging = kwargs.pop('tagging', True)
     multiple = kwargs.pop('multiple', False)
-
-    if required:
-        if not form_name:
-            raise ValueError('You must pass formname if you pass required')
 
     if lookuplist is None:
         other_show = None
@@ -232,7 +226,6 @@ def select(*args, **kwargs):
         'lookuplist': lookuplist,
         'placeholder': placeholder,
         'default_null': default_null,
-        'form_name': form_name,
         'directives': args,
         'visibility': visibility,
         'help_template': help_template,

--- a/opal/tests/test_templatetags_forms.py
+++ b/opal/tests/test_templatetags_forms.py
@@ -107,11 +107,6 @@ class InputTest(TestCase):
         tpl = Template('{% load forms %}{% input label="hai" model="bai[0].something" %}')
         self.assertIn('bai0_something', tpl.render(Context({})))
 
-    def test_required_no_formname(self):
-        tpl = Template('{% load forms %}{% input label="hai" model="bai" required=True%}')
-        with self.assertRaises(ValueError):
-            tpl.render(Context({}))
-
 
 class CheckboxTestCase(TestCase):
 

--- a/opal/tests/test_templatetags_forms.py
+++ b/opal/tests/test_templatetags_forms.py
@@ -183,11 +183,6 @@ class SelectTestCase(TestCase):
         rendered = template.render(Context({}))
         self.assertIn('informative help text', rendered)
 
-    def test_required_no_formname(self):
-        tpl = Template('{% load forms %}{% select label="hai" model="bai" required=True %}')
-        with self.assertRaises(ValueError):
-            tpl.render(Context({}))
-
     def test_load_from_model(self):
         tpl = Template('{% load forms %}{% select field="DogOwner.dog" %}')
         rendered = tpl.render(Context({}))


### PR DESCRIPTION
… modals and pathways. You can override it if you want, but the only reason you'd want to is if we had multiple forms on the same page, which is not usecase we have at the moment