### PR TITLE
we now allow an empty hospital number in bulk create

### DIFF
--- a/opal/models.py
+++ b/opal/models.py
@@ -473,9 +473,7 @@ class Patient(models.Model):
         """
         if "demographics" not in dict_of_list_of_upgrades:
             if not self.id:
-                raise ValueError(
-                    "demographics are required when creating a new patient"
-                )
+                dict_of_list_of_upgrades["demographics"] = [{}]
 
         if not self.id:
             self.save()

--- a/opal/tests/test_models.py
+++ b/opal/tests/test_models.py
@@ -117,8 +117,8 @@ class PatientTestCase(OpalTestCase):
             ]
         }
 
-        with self.assertRaises(ValueError):
-            original_patient.bulk_update(d, self.user)
+        original_patient.bulk_update(d, self.user)
+        self.assertIsNone(original_patient.demographics_set.first().hospital_number)
 
     def test_bulk_update_tagging_ignored(self):
         original_patient = models.Patient()


### PR DESCRIPTION
so the requirement of having a hospital number is invalid, if we need it we should get it in the pathway or whatever is using the bulk create