### PR TITLE
Remove field resets

### DIFF
--- a/opal/static/js/opal/controllers/edit_item.js
+++ b/opal/static/js/opal/controllers/edit_item.js
@@ -44,13 +44,6 @@ angular.module('opal.controllers').controller(
 		        };
                 var watchName = "editing." + item.columnName + ".test"
 		        $scope.$watch(watchName, function(testName) {
-
-                    _.each(_.keys($scope.editing[item.columnName]), function(field){
-                        if(field !== "test" && field !== "date_ordered" && field !== "alert_investigation"  && field !== "id" && field !== "episode_id" && field !== "consistency_token"){
-                            $scope.editing[item.columnName][field] = undefined;
-                        }
-                    });
-
 			        $scope.testType = $scope.microbiology_test_lookup[testName];
                     if( _.isUndefined(testName) || _.isUndefined($scope.testType) ){
                         return;

--- a/opal/static/js/opaltest/edit_item.controller.test.js
+++ b/opal/static/js/opaltest/edit_item.controller.test.js
@@ -305,32 +305,6 @@ describe('EditItemCtrl', function (){
             $scope.$digest();
             expect($scope.editing.microbiology_test.c_difficile_antigen).toEqual("pending");
             expect($scope.editing.microbiology_test.c_difficile_toxin).toEqual("pending");
-            $scope.editing.microbiology_test.test = ""
-            $scope.$digest();
-            expect($scope.editing.microbiology_test.c_difficile_antigen).not.toEqual("pending");
-            expect($scope.editing.microbiology_test.c_difficile_toxin).not.toEqual("pending");
-            expect($scope.editing.microbiology_test.consistency_token).toEqual("23423223");
-        });
-
-        it('should should not clean id, date ordered or episode id', function(){
-            var today = moment().format('DD/MM/YYYY');
-            $scope.editing.microbiology_test.test = "C diff";
-            $scope.editing.microbiology_test.alert_investigation = true;
-            $scope.$digest();
-            $scope.editing.microbiology_test.c_difficile_antigen = "pending";
-            $scope.editing.microbiology_test.episode_id = 1;
-            $scope.editing.microbiology_test.id = 2;
-            $scope.editing.microbiology_test.date_ordered = today;
-            $scope.editing.microbiology_test.consistency_token = "122112";
-            $scope.editing.microbiology_test.test = "";
-            $scope.$digest();
-
-            expect($scope.editing.microbiology_test.c_difficile_antigen).not.toEqual("pending");
-            expect($scope.editing.microbiology_test.episode_id).toBe(1);
-            expect($scope.editing.microbiology_test.id).toBe(2);
-            expect($scope.editing.microbiology_test.consistency_token).toBe("122112");
-            expect($scope.editing.microbiology_test.date_ordered).toBe(today);
-            expect($scope.editing.microbiology_test.alert_investigation).toBe(true);
         });
     });
 


### PR DESCRIPTION
the reset of object properties for fields such as result meant we nuk…ed the field and replaced it by the default. This reopens the bug that if you set a field and then chagne the test name it will change the field, however this is better than the current state