### PR TITLE
remove controller for episode

### DIFF
--- a/opal/static/js/opal/controllers/patient_list.js
+++ b/opal/static/js/opal/controllers/patient_list.js
@@ -373,17 +373,6 @@ angular.module('opal.controllers').controller(
             $scope.rix = rix;
         }
 
-        $scope.controller_for_episode = function(controller, template, size, episode){
-            $modal.open({
-                controller : controller,
-                templateUrl: template,
-                size       : size,
-                resolve    : {
-                    episode: function(){ return episode }
-                }
-            });
-        }
-
         $scope.keyboard_shortcuts = function(){
             $modal.open({
                 controller: "KeyBoardShortcutsCtrl",


### PR DESCRIPTION
this was only used by opal-observations and has been change to use open_modal as part of https://github.com/openhealthcare/opal-observations/pull/31