### PR TITLE
remove the options from the tag list

### DIFF
--- a/opal/templates/partials/_teams_list.html
+++ b/opal/templates/partials/_teams_list.html
@@ -6,7 +6,7 @@
 <hr />
 <h4
    ng-repeat="tag in episode.getTags()"
-   ng-show="options.tag_visible_in_list.indexOf(tag) != -1"
+   ng-show="metadata.tag_visible_in_list.indexOf(tag) != -1"
    >
-  <a href="/#/list/[[ tag ]]" >[[ tag_display[tag] ]]</a>
+  <a href="/#/list/[[ metadata.tags[tag].slug ]]" >[[ metadata.tags[tag].display_name ]]</a>
 </h4>


### PR DESCRIPTION
we should bring the tag_visible_in_list logic into the metadata.tags name space, its a bit cleaner than doing indexOf (I think)