### PR TITLE
Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.5"
   - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - python setup.py develop
   - gem install coveralls-lcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Any controllers attempting to open the modal e.g. custom list flows should updat
 Opal 0.8.0 is the first version of Opal to support Python 3. This has meant changing the default
 ordering of `PatientList` instances to 0 rather than None.
 
-Moving forwards we expect all new code in Opal to be compatible with both Python 2.7 and 3.5.
+Moving forwards we expect all new code in Opal to be compatible both Python 2.7 / 3.4 / 3.5 / 3.6.
 
 This introduces an explicit Opal dependency on the Six module for maintaining codebases that span
 Python 2.x and 3.x.

--- a/opal/core/discoverable.py
+++ b/opal/core/discoverable.py
@@ -16,13 +16,13 @@ def import_from_apps(module):
     This way we allow our implementation, or plugins, to define their
     own ward rounds.
     """
+    global IMPORTED_FROM_APPS
     if not module in IMPORTED_FROM_APPS:
         for app in settings.INSTALLED_APPS:
             try:
                 stringport('{0}.{1}'.format(app, module))
             except ImportError:
                 pass # not a problem
-        global IMPORTED_FROM_APPS
         IMPORTED_FROM_APPS.add(module)
         return
 

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,6 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 )


### PR DESCRIPTION
Almost no changes required, but we did get bitten by : 

```A global or nonlocal statement must now textually appear before the first use of the affected name in the same scope. Previously this was a SyntaxWarning.```

https://docs.python.org/3/whatsnew/3.6.html