### PR TITLE
931 patient list sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,11 @@ Python 2.x and 3.x.
 Adds the class `opal.core.patient_lists.TabbedPatientListGroup` which displays groups of related
 lists as tabs at the top of each member list.
 
+#### PatientList sort order
+
+To enable custom sort orders for individual `PatientList`s we introduce the `comparator_service` attribute.
+This names an Angular service which will return a list of comparator functions.
+
 #### Template re-naming
 
 Modal_base has now been moved into a folder called base_templates. Its also now got a form_modal_base and a two_column_form_modal_base.

--- a/doc/docs/guides/list_views.md
+++ b/doc/docs/guides/list_views.md
@@ -128,6 +128,37 @@ set to false, users will not be able to add the tag for this list.
         tag = 'liaisonpatients'
         direct_add = False
 
+
+### Customising Sort order of Episodes
+
+By default, PatientLists sort according to the Angular method `Episode.compare`. You may override this
+on a list-by-list basis by setting the `comparator_service` attribute.
+
+```python
+class MySortedList(PatientList):
+    comparator_service = 'MyComparatorService'
+```
+
+This attribute should be the name of an Angular service that returns a list of comparator functions.
+For instance, to sort by Episode.category_name then Episode id:
+
+```javascript
+angular.module('opal.services')
+    .factory('MyComparatorService', function(){
+        "use strict";
+        return [
+            function(e){ return e.category_name },
+            function(e){ return e.id }
+        ]
+    })
+```
+
+<blockquote><small>
+The file containing your comparator service must be included in the javascripts <br />
+of your application or plugin in order to be available on the client.
+</small></blockquote>
+
+
 ### Access Control
 
 As PatientLists are a [RestrictableFeature](discoverable.md#restrictable-features), Access control

--- a/doc/docs/reference/patient_list.md
+++ b/doc/docs/reference/patient_list.md
@@ -12,6 +12,10 @@ The `patient_lists` module defines a number of classes for working with lists of
 
 How we want to refer to this list on screen to users.
 
+#### PatientList.comparator_service
+
+A custom comparator service to set sort order within a list. Defaults to None.
+
 ## TaggedPatientList
 
 Tagged Patient Lists inherit from Patient Lists - as such they have all of the same methods and properties

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -11,9 +11,10 @@ class PatientList(discoverable.DiscoverableFeature,
     A view of a list shown on the list page, complete with schema that
     define the columns shown and a queryset that defines the episodes shown
     """
-    module_name   = 'patient_lists'
-    template_name = 'patient_lists/spreadsheet_list.html'
-    order         = 0
+    module_name        = 'patient_lists'
+    template_name      = 'patient_lists/spreadsheet_list.html'
+    order              = 0
+    comparator_service = None
 
     @classmethod
     def list(klass):

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -251,3 +251,14 @@ class TaggedPatientListMetadata(metadata.Metadata):
             direct_add=True,
         )
         return data
+
+
+class PatientListComparatorMetadata(metadata.Metadata):
+    slug = 'patient_list_comparators'
+
+    @classmethod
+    def to_dict(klass, user=None, **kw):
+        lists = [p for p in PatientList.for_user(user) if p.comparator_service]
+        return {klass.slug: {
+            plist.get_slug(): plist.comparator_service for plist in lists
+        }}

--- a/opal/static/js/opal/controllers/patient_list.js
+++ b/opal/static/js/opal/controllers/patient_list.js
@@ -58,7 +58,7 @@ angular.module('opal.controllers').controller(
             if($scope.comparators){
                 return p1.compare(p2, $scope.comparators);
             }else{
-		        return p1.compare(p2);
+                return p1.compare(p2);
             }
 	    };
 

--- a/opal/static/js/opal/services/episode.js
+++ b/opal/static/js/opal/services/episode.js
@@ -11,7 +11,7 @@ angular.module('opal.services')
 	        var episode = this;
 	        var column, field, attrs;
 
-          episode.recordEditor = new RecordEditor(episode);
+            episode.recordEditor = new RecordEditor(episode);
 
             // We would like everything for which we have data that is a field to
             // be an instantiated instance of Item - not just those fields in the
@@ -129,7 +129,26 @@ angular.module('opal.services')
                 return copy
             };
 
-	        this.compare = function(other) {
+	        this.compare = function(other, comparators) {
+                //
+                // The default comparators we use for our Episode sorting in lists
+                //
+                var comparators = comparators || [
+  		            function(p) { return CATEGORIES.indexOf(p.location[0].category) },
+  		            function(p) { return p.location[0].hospital },
+                    // TODO: remove this UCH specific code from Opal
+  		            function(p) {
+  		                if (p.location[0].hospital == 'UCH' &&
+                            p.location[0].ward.match(/^T\d+/)) {
+  			                return parseInt(p.location[0].ward.substring(1));
+  		                } else {
+  			                return p.location[0].ward
+  		                }
+  		            },
+  		            function(p) { return parseInt(p.location[0].bed) }
+  	            ];
+
+                // Todo: remove this UCH list specific code from Opal
                 if($routeParams.tag === "walkin" && $routeParams.subtag === "walkin_review"){
                     var getName = function(x){
                         var surname = x.demographics[0].surname.toLowerCase()
@@ -137,49 +156,24 @@ angular.module('opal.services')
                         return first_name + " " + surname;
                     };
 
-                    if(other.date_of_episode > this.date_of_episode){
-                        return -1;
-                    }
-                    else if(other.date_of_episode < this.date_of_episode){
-                        return 1;
-                    }
-                    else if(getName(other) > getName(this)){
-                        return -1;
-                    }
-                    else if(getName(other) < getName(this)){
-                        return 1;
-                    }
-
-                    return 0;
+                    comparators = [
+                        function(p){ return p.date_of_episode },
+                        function(p){ return getName(p) }
+                    ]
                 }
-                else{
-                    var v1, v2;
-  	                var comparators = [
-  		                function(p) { return CATEGORIES.indexOf(p.location[0].category) },
-  		                function(p) { return p.location[0].hospital },
-  		                function(p) {
-  		                    if (p.location[0].hospital == 'UCH' &&
-                                p.location[0].ward.match(/^T\d+/)) {
-  			                    return parseInt(p.location[0].ward.substring(1));
-  		                    } else {
-  			                    return p.location[0].ward
-  		                    }
-  		                },
-  		                function(p) { return parseInt(p.location[0].bed) }
-  	                ];
 
-  	                for (var ix = 0; ix < comparators.length; ix++) {
-  		                v1 = comparators[ix](episode);
-  		                v2 = comparators[ix](other);
-  		                if (v1 < v2) {
-  		                    return -1;
-  		                } else if (v1 > v2) {
-  		                    return 1;
-  		                }
-  	                }
+                var v1, v2;
+  	            for (var ix = 0; ix < comparators.length; ix++) {
+  		            v1 = comparators[ix](episode);
+  		            v2 = comparators[ix](other);
+  		            if (v1 < v2) {
+  		                return -1;
+  		            } else if (v1 > v2) {
+  		                return 1;
+  		            }
+  	            }
 
-  	                return 0;
-                }
+  	            return 0;
 	        };
 
             //
@@ -251,8 +245,8 @@ recently changed it - refresh the page and try again');
         Episode.findByHospitalNumber = function(number, callbacks){
             var deferred = $q.defer();
             var result = {
-    				patients: [],
-    				hospitalNumber: number
+    			patients: [],
+    			hospitalNumber: number
 			};
             // record loader is sued by the field translater to
             // cast the results fields
@@ -273,8 +267,8 @@ recently changed it - refresh the page and try again');
                     .success(function(response) {
 					    // We have retrieved patient records matching the hospital number
   					    result.patients = response;
-                // cast the patient fields
-                deferred.resolve(result);
+                        // cast the patient fields
+                        deferred.resolve(result);
 
 				    });
             }else{

--- a/opal/static/js/opal/services/episode.js
+++ b/opal/static/js/opal/services/episode.js
@@ -148,20 +148,6 @@ angular.module('opal.services')
   		            function(p) { return parseInt(p.location[0].bed) }
   	            ];
 
-                // Todo: remove this UCH list specific code from Opal
-                if($routeParams.tag === "walkin" && $routeParams.subtag === "walkin_review"){
-                    var getName = function(x){
-                        var surname = x.demographics[0].surname.toLowerCase()
-                        var first_name = x.demographics[0].first_name.toLowerCase()
-                        return first_name + " " + surname;
-                    };
-
-                    comparators = [
-                        function(p){ return p.date_of_episode },
-                        function(p){ return getName(p) }
-                    ]
-                }
-
                 var v1, v2;
   	            for (var ix = 0; ix < comparators.length; ix++) {
   		            v1 = comparators[ix](episode);

--- a/opal/static/js/opaltest/episode.service.test.js
+++ b/opal/static/js/opaltest/episode.service.test.js
@@ -169,6 +169,23 @@ describe('Episode', function() {
         expect(johnSmith.compare(anneAngela)).toEqual(-1);
     });
 
+    it('should be equal for non UCH hospitals', function() {
+        var datacopy = angular.copy(episodeData);
+        datacopy.location[0].hospital = 'RFH';
+        var first       = new Episode(datacopy);
+        var second      = new Episode(datacopy);
+        expect(first.compare(second)).toEqual(0);
+    });
+
+    it('should allow custom comparators to be passed.', function() {
+        var comparators = [jasmine.createSpy().and.returnValue(-1000)];
+        var first       = new Episode(episodeData);
+        var second      = new Episode(episodeData);
+        expect(first.compare(second, comparators)).toEqual(0);
+        expect(comparators[0]).toHaveBeenCalledWith(first)
+        expect(comparators[0]).toHaveBeenCalledWith(second)
+    });
+
     it('Should have access to the attributes', function () {
         expect(episode.active).toEqual(true);
     });

--- a/opal/static/js/opaltest/episode.service.test.js
+++ b/opal/static/js/opaltest/episode.service.test.js
@@ -150,25 +150,6 @@ describe('Episode', function() {
         });
     });
 
-    it('should run walkin comparison in walkin review', function(){
-        $routeParams.tag = "walkin";
-        $routeParams.subtag = "walkin_review";
-        var anneAngelaData = angular.copy(episodeData);
-        var johnSmith = new Episode(episodeData);
-        anneAngelaData.demographics[0].first_name = "Anne";
-        anneAngelaData.demographics[0].surname = "Angela";
-        var anneAngela = new Episode(anneAngelaData);
-        expect(johnSmith.compare(anneAngela)).toEqual(1);
-
-        johnSmith.date_of_episode = new Date(2015, 10, 11);
-        var johnSmithOld = new Episode(episodeData);
-        johnSmithOld.date_of_episode = new Date(2015, 10, 10);
-        expect(johnSmithOld.compare(johnSmith)).toEqual(-1);
-
-        anneAngela.date_of_episode = new Date(2015, 10, 12);
-        expect(johnSmith.compare(anneAngela)).toEqual(-1);
-    });
-
     it('should be equal for non UCH hospitals', function() {
         var datacopy = angular.copy(episodeData);
         datacopy.location[0].hospital = 'RFH';

--- a/opal/static/js/opaltest/patient_list.controller.test.js
+++ b/opal/static/js/opaltest/patient_list.controller.test.js
@@ -467,6 +467,16 @@ describe('PatientListCtrl', function() {
 
         });
 
+        describe('n', function() {
+
+            it('should addEpisode()', function() {
+                spyOn($scope, 'addEpisode');
+                $scope.$broadcast('keydown', { keyCode: 78 });
+                expect($scope.addEpisode).toHaveBeenCalledWith();
+            });
+
+        });
+
     });
 
     describe('print()', function() {

--- a/opal/static/js/opaltest/patient_list.controller.test.js
+++ b/opal/static/js/opaltest/patient_list.controller.test.js
@@ -563,7 +563,8 @@ describe('PatientListCtrl', function() {
                 }
             );
             $scope.addEpisode();
-            expect(growl.success).toHaveBeenCalledWith('John Smith added to the OPAT Referral list');
+            expect(growl.success).toHaveBeenCalledWith(
+                'John Smith added to the OPAT Referral list');
         });
 
         it('should add the new episode to episodes if it has the current tag', function() {
@@ -573,13 +574,14 @@ describe('PatientListCtrl', function() {
             expect($scope.rows.length).toBe(2);
         });
 
-        it('should not add the new episode to episodes if it does not have the current tag', function() {
-            episodeData2.tagging = [{'mine': true, 'id_inpatients': true}];
-            spyOn(Flow, 'enter').and.callFake(fake_episode_resolver);
-            expect($scope.rows.length).toBe(1);
-            $scope.addEpisode();
-            expect($scope.rows.length).toBe(1);
-        });
+        it('should not add the new episode to episodes if it does not have the current tag',
+           function() {
+               episodeData2.tagging = [{'mine': true, 'id_inpatients': true}];
+               spyOn(Flow, 'enter').and.callFake(fake_episode_resolver);
+               expect($scope.rows.length).toBe(1);
+               $scope.addEpisode();
+               expect($scope.rows.length).toBe(1);
+           });
 
         describe('for a readonly user', function(){
             beforeEach(function(){
@@ -593,6 +595,22 @@ describe('PatientListCtrl', function() {
             afterEach(function(){
                 profile.readonly = false;
             });
+        });
+
+        describe('When the modal is dismissed', function() {
+
+            it('should reset the state', function() {
+                spyOn(Flow, 'enter').and.callFake(
+                    function(){
+                        return {
+                            then : function(cb, eb){ eb() }
+                        }
+                    }
+                );
+                $scope.addEpisode()
+                expect($rootScope.state).toEqual('normal');
+            });
+
         });
     });
 

--- a/opal/static/js/opaltest/patient_list.controller.test.js
+++ b/opal/static/js/opaltest/patient_list.controller.test.js
@@ -754,6 +754,20 @@ describe('PatientListCtrl', function() {
             var isRemoved = _.contains(displayed_episodes, selectedEpisodeId);
             expect(isRemoved).toBe(true);
         });
+
+        it('should call removeFromList', function() {
+            var selectedEpisodeId = $scope.episode.id;
+            profile.readonly = false;
+            spyOn($scope, 'removeFromList');
+            spyOn($scope.episode.tagging[0], 'save').and.returnValue({
+                then: function(f){ f() }
+            })
+            $scope.removeFromMine($scope.episode);
+            $scope.$apply();
+
+            expect($scope.removeFromList).toHaveBeenCalledWith($scope.episode)
+        });
+
     });
 
     describe('newNamedItem', function(){

--- a/opal/static/js/opaltest/patient_list.controller.test.js
+++ b/opal/static/js/opaltest/patient_list.controller.test.js
@@ -773,14 +773,17 @@ describe('PatientListCtrl', function() {
         });
     });
 
-    describe('adding an item', function() {
-        var iix;
+    describe('editNamedItem', function() {
 
-        beforeEach(function() {
-            iix = episodeData.diagnosis.length;
+        it('should call reset_state() when we return', function() {
+            spyOn($scope.episode.recordEditor, 'editItem').and.returnValue(
+                { then: function(f){ f() }}
+            );
+            $scope.editNamedItem($scope.episode, 'diagnosis', 0);
         });
 
-        it('should call through to the record editor', function() {
+        it('should call through to the record editor when we add an item', function() {
+            var iix = episodeData.diagnosis.length;
             $scope.editNamedItem($scope.episode, "diagnosis", iix);
             expect($scope.episode.recordEditor.editItem).toHaveBeenCalledWith(
                 'diagnosis', iix

--- a/opal/static/js/opaltest/patient_list.controller.test.js
+++ b/opal/static/js/opaltest/patient_list.controller.test.js
@@ -775,11 +775,13 @@ describe('PatientListCtrl', function() {
 
     describe('editNamedItem', function() {
 
-        it('should call reset_state() when we return', function() {
-            spyOn($scope.episode.recordEditor, 'editItem').and.returnValue(
+        it('should re-check visibility if we edit tagging', function() {
+            spyOn($scope, 'getVisibleEpisodes');
+            $scope.episode.recordEditor.editItem.and.returnValue(
                 { then: function(f){ f() }}
             );
-            $scope.editNamedItem($scope.episode, 'diagnosis', 0);
+            $scope.editNamedItem($scope.episode, 'tagging', 0);
+            expect($scope.getVisibleEpisodes).toHaveBeenCalledWith();
         });
 
         it('should call through to the record editor when we add an item', function() {

--- a/opal/static/js/opaltest/patient_list.controller.test.js
+++ b/opal/static/js/opaltest/patient_list.controller.test.js
@@ -103,17 +103,17 @@ describe('PatientListCtrl', function() {
                 name: "tropical"
             },
             mine: {
-              direct_add: true,
-              display_name: 'Mine',
-              name: 'mine',
-              slug: 'mine'
+                direct_add: true,
+                display_name: 'Mine',
+                name: 'mine',
+                slug: 'mine'
             },
             icu: {
-              direct_add: true,
-              display_name: 'ICU',
-              name: 'icu',
-              slug: 'icu'
-          }
+                direct_add: true,
+                display_name: 'ICU',
+                name: 'icu',
+                slug: 'icu'
+            }
         }
     };
 
@@ -204,42 +204,42 @@ describe('PatientListCtrl', function() {
     }));
 
     describe("edit Tags", function(){
-      it('should filter an episode if the episode does not have the same tags', function(){
-        // imitate the case where we remove all the tags
-        $scope.episodes[episode.id] = episode;
-        $scope.episodes[episode2.id] = episode2;
-        $scope.rows = [episode, episode2];
-        var scopeChanged = false;
-        $rootScope.$watch("state.modal", function(ca){
-          scopeChanged = true;
-        });
-
-        $scope.open_modal = function(){};
-        spyOn($scope, "open_modal").and.returnValue({then: function(fn){ episode.tagging = [{}]; fn(); }});
-        $scope.editTags();
-        $scope.$apply();
-        expect($scope.rows).toEqual([episode2]);
-        expect($scope.episodes[episode.id]).toBe(undefined);
-        expect($scope.open_modal).toHaveBeenCalled();
-        expect(scopeChanged).toBe(true);
-        expect($rootScope.state).toBe("normal");
-      });
-
-      it('should leave the episode if it does have the pertinant tag', function(){
         it('should filter an episode if the episode does not have the same tags', function(){
-          // imitate the case where we remove all the tags
-          $scope.episodes[episode.id] = episode;
-          episode.tagging.micro_orth = true;
-          $scope.episodes[episode2.id] = episode2;
-          $scope.rows = [episode, episode2];
-          $scope.open_modal = function(){};
-          spyOn($scope, "open_modal").and.returnValue({then: function(fn){ delete episode.tagging.micro_orth; fn(); }});
-          $scope.editTags();
-          expect($scope.rows).toEqual([episode, episode2]);
-          expect($scope.episodes[episode.id]).toBe(episode);
-          expect($scope.open_modal).toHaveBeenCalled();
+            // imitate the case where we remove all the tags
+            $scope.episodes[episode.id] = episode;
+            $scope.episodes[episode2.id] = episode2;
+            $scope.rows = [episode, episode2];
+            var scopeChanged = false;
+            $rootScope.$watch("state.modal", function(ca){
+                scopeChanged = true;
+            });
+
+            $scope.open_modal = function(){};
+            spyOn($scope, "open_modal").and.returnValue({then: function(fn){ episode.tagging = [{}]; fn(); }});
+            $scope.editTags();
+            $scope.$apply();
+            expect($scope.rows).toEqual([episode2]);
+            expect($scope.episodes[episode.id]).toBe(undefined);
+            expect($scope.open_modal).toHaveBeenCalled();
+            expect(scopeChanged).toBe(true);
+            expect($rootScope.state).toBe("normal");
         });
-      });
+
+        it('should leave the episode if it does have the pertinant tag', function(){
+            it('should filter an episode if the episode does not have the same tags', function(){
+                // imitate the case where we remove all the tags
+                $scope.episodes[episode.id] = episode;
+                episode.tagging.micro_orth = true;
+                $scope.episodes[episode2.id] = episode2;
+                $scope.rows = [episode, episode2];
+                $scope.open_modal = function(){};
+                spyOn($scope, "open_modal").and.returnValue({then: function(fn){ delete episode.tagging.micro_orth; fn(); }});
+                $scope.editTags();
+                expect($scope.rows).toEqual([episode, episode2]);
+                expect($scope.episodes[episode.id]).toBe(episode);
+                expect($scope.open_modal).toHaveBeenCalled();
+            });
+        });
     });
 
 
@@ -354,29 +354,29 @@ describe('PatientListCtrl', function() {
         var episodeData3;
 
         beforeEach(function(){
-          $scope.episodes[episode.id] = episode;
-          $scope.episodes[episode2.id] = episode2;
-          episodeData3 = angular.copy(episodeData2);
-          episodeData3.id = 125;
-          episodeData3.demographics[0].first_name = "Suzy";
-          episodeData3.demographics[0].surname = "Vega";
+            $scope.episodes[episode.id] = episode;
+            $scope.episodes[episode2.id] = episode2;
+            episodeData3 = angular.copy(episodeData2);
+            episodeData3.id = 125;
+            episodeData3.demographics[0].first_name = "Suzy";
+            episodeData3.demographics[0].surname = "Vega";
 
-          $scope.episodes[episodeData3.id] = new Episode(episodeData3);
+            $scope.episodes[episodeData3.id] = new Episode(episodeData3);
 
-          $scope.rows = [
-            episode,
-            episode2,
-            $scope.episodes[episodeData3.id]
-          ];
+            $scope.rows = [
+                episode,
+                episode2,
+                $scope.episodes[episodeData3.id]
+            ];
 
-          $scope.episode = episode;
+            $scope.episode = episode;
         });
 
 
         it('should select the only available episode if filtered to one', function(){
             /*
-            so if episode visibility filters out all but one response
-            we expect that episode to now be selected
+              so if episode visibility filters out all but one response
+              we expect that episode to now be selected
             */
             expect($scope.episode.id).toEqual(episodeData.id);
 
@@ -391,9 +391,9 @@ describe('PatientListCtrl', function() {
 
         it('should maintain the same episode if its still present', function(){
             /*
-            so if episode visibility does not filter
-            anything out, we expect the in scope episode to
-            be the same
+              so if episode visibility does not filter
+              anything out, we expect the in scope episode to
+              be the same
             */
             expect($scope.episode.id).toEqual(episodeData.id);
 
@@ -418,9 +418,9 @@ describe('PatientListCtrl', function() {
 
         it('if no episodes are available, keep using the last selected one', function(){
             /*
-            so if episode visibility does not filter
-            anything out, we expect the in scope episode to
-            be the same
+              so if episode visibility does not filter
+              anything out, we expect the in scope episode to
+              be the same
             */
             expect($scope.episode.id).toEqual(episodeData.id);
 
@@ -448,12 +448,23 @@ describe('PatientListCtrl', function() {
             expect($location.url).toHaveBeenCalledWith($scope.episode.link);
         });
 
-        it('should go up', function() {
-            $scope.$broadcast('keydown', { keyCode: 38 });
-        });
+        describe('Moving episode', function() {
+            beforeEach(function(){
+                $scope.rows.push(episode2)
+            });
 
-        it('should go up', function() {
-            $scope.$broadcast('keydown', { keyCode: 40 });
+            it('should go up', function() {
+                $scope.rix = 1;
+                $scope.$broadcast('keydown', { keyCode: 38 });
+                expect($scope.rix).toEqual(0);
+            });
+
+            it('should go down', function() {
+                expect($scope.rix).toEqual(0);
+                $scope.$broadcast('keydown', { keyCode: 40 });
+                expect($scope.rix).toEqual(1);
+            });
+
         });
 
     });
@@ -521,38 +532,38 @@ describe('PatientListCtrl', function() {
         });
 
         it('should print the correct message even dependent on the current tag', function(){
-          $scope.currentTag = 'tropical';
-          spyOn(Flow, 'enter').and.callFake(
-              function(){
-                  return {
-                      then : function(fn){ fn({
-                          then: function(fn){ fn(new Episode(episodeData) ) }
-                      })}
-                  }
-              }
-          );
-          $scope.addEpisode();
-          expect(growl.success).toHaveBeenCalledWith('John Smith added to the Tropical list');
+            $scope.currentTag = 'tropical';
+            spyOn(Flow, 'enter').and.callFake(
+                function(){
+                    return {
+                        then : function(fn){ fn({
+                            then: function(fn){ fn(new Episode(episodeData) ) }
+                        })}
+                    }
+                }
+            );
+            $scope.addEpisode();
+            expect(growl.success).toHaveBeenCalledWith('John Smith added to the Tropical list');
         });
 
         it('should print the correct message even in the case of multiple tags with hierarchies on the current tag', function(){
-          $scope.currentTag = 'opat';
-          $scope.currentSubTag = 'opat_referrals';
-          var episodeData3 = angular.copy(episodeData);
-          episodeData3.tagging = [
-              {opat: true, opat_referrals: true, mine: true}
-          ];
-          spyOn(Flow, 'enter').and.callFake(
-              function(){
-                  return {
-                      then : function(fn){ fn({
-                          then: function(fn){ fn(new Episode(episodeData3) ) }
-                      })}
-                  }
-              }
-          );
-          $scope.addEpisode();
-          expect(growl.success).toHaveBeenCalledWith('John Smith added to the OPAT Referral list');
+            $scope.currentTag = 'opat';
+            $scope.currentSubTag = 'opat_referrals';
+            var episodeData3 = angular.copy(episodeData);
+            episodeData3.tagging = [
+                {opat: true, opat_referrals: true, mine: true}
+            ];
+            spyOn(Flow, 'enter').and.callFake(
+                function(){
+                    return {
+                        then : function(fn){ fn({
+                            then: function(fn){ fn(new Episode(episodeData3) ) }
+                        })}
+                    }
+                }
+            );
+            $scope.addEpisode();
+            expect(growl.success).toHaveBeenCalledWith('John Smith added to the OPAT Referral list');
         });
 
         it('should add the new episode to episodes if it has the current tag', function() {
@@ -612,8 +623,8 @@ describe('PatientListCtrl', function() {
                 $scope.episodes[episodeData.id] = episode;
                 $scope.episodes[episodeData2.id] = episode2;
                 $scope.rows = [
-                  $scope.episodes[episode.id],
-                  $scope.episodes[episode2.id]
+                    $scope.episodes[episode.id],
+                    $scope.episodes[episode2.id]
                 ];
                 $scope._post_discharge('discharged', episode);
                 var first_name = $scope.select_episode.calls.allArgs()[0][0].demographics[0].first_name;
@@ -715,41 +726,41 @@ describe('PatientListCtrl', function() {
     });
 
     describe('removeFromMine()', function() {
-      it('should be null if readonly', function() {
-          profile.readonly = true;
+        it('should be null if readonly', function() {
+            profile.readonly = true;
 
-          var rows = _.map($scope.rows, function(episode){
-            return episode.id;
-          });
-          expect($scope.removeFromMine($scope.episode));
-          $rootScope.$apply();
-          var newRows = _.map($scope.rows, function(episode){
-            return episode.id;
-          });
-          expect(rows).toEqual(newRows);
-      });
+            var rows = _.map($scope.rows, function(episode){
+                return episode.id;
+            });
+            expect($scope.removeFromMine($scope.episode));
+            $rootScope.$apply();
+            var newRows = _.map($scope.rows, function(episode){
+                return episode.id;
+            });
+            expect(rows).toEqual(newRows);
+        });
 
-      it('should remove the mine tag', function() {
-          var selectedEpisodeId = $scope.episode.id;
-          profile.readonly = false;
-          $scope.removeFromMine($scope.episode);
-          $rootScope.$apply();
+        it('should remove the mine tag', function() {
+            var selectedEpisodeId = $scope.episode.id;
+            profile.readonly = false;
+            $scope.removeFromMine($scope.episode);
+            $rootScope.$apply();
 
-          // the episode should be removed from the displayed episodes
-          var displayed_episodes = _.map($scope.rows, function(episode){
-            return episode.id;
-          });
+            // the episode should be removed from the displayed episodes
+            var displayed_episodes = _.map($scope.rows, function(episode){
+                return episode.id;
+            });
 
-          var isRemoved = _.contains(displayed_episodes, selectedEpisodeId);
-          expect(isRemoved).toBe(true);
-      });
+            var isRemoved = _.contains(displayed_episodes, selectedEpisodeId);
+            expect(isRemoved).toBe(true);
+        });
     });
 
     describe('newNamedItem', function(){
         it('should pass through the current scopes tags', function(){
-          spyOn(episode.recordEditor, "newItem");
-          $scope.newNamedItem(episode, "someName");
-          expect(episode.recordEditor.newItem).toHaveBeenCalledWith("someName")
+            spyOn(episode.recordEditor, "newItem");
+            $scope.newNamedItem(episode, "someName");
+            expect(episode.recordEditor.newItem).toHaveBeenCalledWith("someName")
         });
     });
 

--- a/opal/static/js/opaltest/patient_list.controller.test.js
+++ b/opal/static/js/opaltest/patient_list.controller.test.js
@@ -764,16 +764,24 @@ describe('PatientListCtrl', function() {
         });
     });
 
-    describe('editing an item', function() {
+    describe('is_tag_visible_in_list', function() {
+
+        it('should return if the tag is visible', function() {
+            expect($scope.is_tag_visible_in_list('tropical')).toEqual(false);
+            $scope.metadata.tag_visible_in_list = ['tropical'];
+            expect($scope.is_tag_visible_in_list('tropical')).toEqual(true);
+        });
+
+    });
+
+    describe('editNamedItem', function() {
+
         it('should call through to the record editor', function(){
             $scope.editNamedItem($scope.episode, 'demographics', 0);
             expect($scope.episode.recordEditor.editItem).toHaveBeenCalledWith(
                 'demographics', 0
             );
         });
-    });
-
-    describe('editNamedItem', function() {
 
         it('should re-check visibility if we edit tagging', function() {
             spyOn($scope, 'getVisibleEpisodes');

--- a/opal/static/js/opaltest/patient_list.controller.test.js
+++ b/opal/static/js/opaltest/patient_list.controller.test.js
@@ -203,14 +203,6 @@ describe('PatientListCtrl', function() {
 
     }));
 
-    describe('newNamedItem', function(){
-        it('should pass through the current scopes tags', function(){
-          spyOn(episode.recordEditor, "newItem");
-          $scope.newNamedItem(episode, "someName");
-          expect(episode.recordEditor.newItem).toHaveBeenCalledWith("someName")
-        });
-    });
-
     describe("edit Tags", function(){
       it('should filter an episode if the episode does not have the same tags', function(){
         // imitate the case where we remove all the tags
@@ -753,6 +745,14 @@ describe('PatientListCtrl', function() {
       });
     });
 
+    describe('newNamedItem', function(){
+        it('should pass through the current scopes tags', function(){
+          spyOn(episode.recordEditor, "newItem");
+          $scope.newNamedItem(episode, "someName");
+          expect(episode.recordEditor.newItem).toHaveBeenCalledWith("someName")
+        });
+    });
+
     describe('editing an item', function() {
         it('should call through to the record editor', function(){
             $scope.editNamedItem($scope.episode, 'demographics', 0);
@@ -777,5 +777,15 @@ describe('PatientListCtrl', function() {
         });
     });
 
+    describe('keyboard_shortcuts()', function() {
+        it('should open the modal', function() {
+            spyOn($modal, 'open');
+            $scope.keyboard_shortcuts()
+            expect($modal.open).toHaveBeenCalledWith({
+                controller: 'KeyBoardShortcutsCtrl',
+                templateUrl: 'list_keyboard_shortcuts.html'
+            })
+        });
+    });
 
 });

--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -10,7 +10,8 @@ from opal.models import Patient, UserProfile
 from opal.core.test import OpalTestCase
 
 from opal.core import patient_lists
-from opal.core.patient_lists import PatientList, TaggedPatientList, TabbedPatientListGroup
+from opal.core.patient_lists import (PatientList, TaggedPatientList, TabbedPatientListGroup,
+                                     PatientListComparatorMetadata)
 
 """
 Begin discoverable definitions for test cases
@@ -21,6 +22,7 @@ class TaggingTestPatientList(TaggedPatientList):
     tag = "eater"
     subtag = "herbivore"
     order = 4
+    comparator_service = 'HerbivoresSortOrder'
 
     schema = [
         models.Demographics,
@@ -265,3 +267,10 @@ class FirstListMetadataTestCase(OpalTestCase):
             for_user.return_value = nongen()
             slug = patient_lists.FirstListMetadata.to_dict(user=self.user)
             self.assertEqual({'first_list_slug': ''}, slug)
+
+
+class ComparatorMetadataTestCase(OpalTestCase):
+
+    def test_to_dict(self):
+        comparators = PatientListComparatorMetadata.to_dict(user=self.user)
+        self.assertEqual({'eater-herbivore': 'HerbivoresSortOrder'}, comparators['patient_list_comparators'])


### PR DESCRIPTION
Currently the only way to implement a custom sort order for a `PatientList` in an Opal application is to implement the sorting logic in `Episode()` within Opal, referencing the specific `$routeParams` we expect to exist at the time.

This is particularly inelegant and short-sighted ~clusterfuck~ process.

Worse, the [one time we actually "take advantage" of this "feature"](https://github.com/openhealthcare/opal/blob/5a45866f9d88c73edcc6621d3d6f9bc219ad727b/opal/static/js/opal/services/episode.js#L133) we have singularly failed to ensure that it keeps up with the pace of progress in Opal. (The astute reader will have noticed that `PatientList` Angular `$routeParams` don't work like that any more, and instead has the singular `slug` property). This leaves a misleading and crude "trade-off" which no longer even fulfils the desired purpose.

It would be significantly better to allow `PatientList` instances to define a set of custom comparators to use in ordering a list. We do that here as a property on the discoverable definition that names an Angular Service expected to resolve to a list of comparator functions.

The re-implementation of Walkin Review sort order is available to preview on the elCID branch [931-sort-order](https://github.com/openhealthcare/elcid/tree/931-sort-order).

(This PR also adds a selection of extra tests for `PatientListCtrl` as a bonus.)

Closes #931 
