### PR TITLE
254 blank userprofile roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,6 @@ The html attribute 'name' for form elements generated with the Opal `{% forms %}
 {% select field="Demographics.first_name" element_name="...Your Angular expression..." %}
 ```
 
-
 #### Model removals
 
 The models `Team`, `GP`, `CommunityNurse` and `LocatedModel` - marked for removal since 0.6.0
@@ -140,6 +139,10 @@ Look up lists now load in from individual apps. The look for a file at {{ app }}
 
 The default admin url is now `/admin/` - rather than `/admin/?` this results in more readable
 admin urls and is closer to what most applications do with the Django admin.
+
+The roles field `opal.models.UserProfile.roles` has been updated to be `blank=True`. This allows the editing
+of users without specific roles assigned in the Django admin. Although this introduces no changes at the
+database level, this does introduce a migration.
 
 #### Updates to the Dependency Graph
 

--- a/doc/docs/reference/upgrading.md
+++ b/doc/docs/reference/upgrading.md
@@ -5,11 +5,23 @@ application to a later version where there are extra steps required.
 
 ### 0.7.1 -> 0.8.0
 
+#### Upgrading Opal
+
+How you do this depends on how you have configured your application, but updating your
+requirements.txt to update the version should work.
+
+    # requirements.txt
+    opal==0.8.0
+
+After re-installing (via for instance `pip install -r requirements.txt`) you will need to
+run the migrations for Opal 0.6.x
+
+    $ python manage.py migrate opal
+
 #### Options
 
 Options are now an ex-API. Applications should convert to use either Referencedata (canonical terms for common data), or
 Metadata (App specific data you wish to pass into the front end).
-
 
 #### UI Components
 

--- a/opal/migrations/0027_auto_20170114_1302.py
+++ b/opal/migrations/0027_auto_20170114_1302.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('opal', '0026_auto_20161120_2005'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='userprofile',
+            name='roles',
+            field=models.ManyToManyField(to='opal.Role', blank=True),
+        ),
+    ]

--- a/opal/models.py
+++ b/opal/models.py
@@ -1398,7 +1398,7 @@ class UserProfile(models.Model):
     can_extract           = models.BooleanField(default=False, help_text=HELP_EXTRACT)
     readonly              = models.BooleanField(default=False, help_text=HELP_READONLY)
     restricted_only       = models.BooleanField(default=False, help_text=HELP_RESTRICTED)
-    roles                 = models.ManyToManyField(Role)
+    roles                 = models.ManyToManyField(Role, blank=True)
 
     def to_dict(self):
         return dict(


### PR DESCRIPTION
Make opal.UserProfile.roles blank=True 

This prevents irritating errors in the Django admin when editing users, and means that we can ignore the need to have initial roles