### PR TITLE
731 plugins2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### 0.8.0 (Major Release)
 
+#### Plugins
+
+Plugins have been refactored and are now `DiscoverableFeatures`. This should have no impact on existing
+plugins, however the functions `opal.core.plugins.register` and `opal.core.plugins.plugins` are slated for
+removal in 0.9.0
+
+When creating new plugins we will place the plugin definition class in `plugin.py` rather than `__init__.py`
+
 #### opal.core.api.patient_from_pk
 
 A decorator that changes a method that is passed a pk, to a method that is passed a patient.
@@ -130,6 +138,7 @@ Opal 0.8.0 removes a number of un-used features that have been slated for remova
 * `opal.models.Tagging.import_from_reversion`. This one-off classmethod on tagging was introduced to aid with the upgrade from Opal 4.x to 5.0 and has no further utility.
 * The `static` argument from the forms `input` tag. Developers should move to the `static` tag.
 * The _modal option to set on subrecords. This is because we now use large modals across the board.
+
 
 #### Misc changes
 

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -355,7 +355,7 @@ for subrecord in subrecords():
     router.register(sub_name, SubViewSet)
 
 def register_plugin_apis():
-    for plugin in plugins.plugins():
+    for plugin in plugins.OpalPlugin.list():
         for api in plugin.get_apis():
             router.register(*api)
 

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -356,7 +356,7 @@ for subrecord in subrecords():
 
 def register_plugin_apis():
     for plugin in plugins.plugins():
-        for api in plugin.apis:
+        for api in plugin.get_apis():
             router.register(*api)
 
 register_plugin_apis()

--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -152,5 +152,5 @@ def get_all_components():
     All components of an Opal application - all plugins and the application.
     """
     return itertools.chain(
-        plugins.plugins(), [get_app()]
+        plugins.OpalPlugin.list(), [get_app()]
     )

--- a/opal/core/plugins.py
+++ b/opal/core/plugins.py
@@ -59,8 +59,7 @@ class OpalPlugin(discoverable.DiscoverableFeature):
         return {}
 
 
-# These two are only here for legacy reasons.
-# TODO: Consider removing and updating elsewhere.
+# TODO 0.9.0: Remove these
 def register(what):
     warnthem = """
 

--- a/opal/core/plugins.py
+++ b/opal/core/plugins.py
@@ -3,8 +3,11 @@ OPAL PLugin - base class and helpers
 """
 import inspect
 import os
+import warnings
 
 from opal.core import discoverable
+
+warnings.simplefilter('once', DeprecationWarning)
 
 
 class OpalPlugin(discoverable.DiscoverableFeature):
@@ -59,10 +62,28 @@ class OpalPlugin(discoverable.DiscoverableFeature):
 # These two are only here for legacy reasons.
 # TODO: Consider removing and updating elsewhere.
 def register(what):
+    warnthem = """
+
+opal.core.plugins.register is no longer required and will be removed in Opal 0.9.0
+There is no need to register {0} as
+Plugins are now discoverable features.
+
+Please consult the Opal documentation on Plugins for more information.
+""".format(what)
+    warnings.warn(warnthem, DeprecationWarning, stacklevel=2)
     pass
 
 def plugins():
     """
     Generator function for plugin instances
     """
+    warnthem = """
+
+opal.core.plugins.plugins is slated for removal in Opal 0.9.0
+
+Plugins are now discoverable features, an iterable of subclasses may be accessed via
+
+opal.core.plugins.OpalPlugin.list
+"""
+    warnings.warn(warnthem, DeprecationWarning, stacklevel=2)
     return OpalPlugin.list()

--- a/opal/core/plugins.py
+++ b/opal/core/plugins.py
@@ -3,14 +3,16 @@ OPAL PLugin - base class and helpers
 """
 import inspect
 import os
-from django.conf import settings
-from opal.utils import _itersubclasses
+
+from opal.core import discoverable
 
 
-class OpalPlugin(object):
+class OpalPlugin(discoverable.DiscoverableFeature):
     """
     Base class from which all of our plugins inherit.
     """
+    module_name = 'plugin'
+
     urls        = []
     javascripts = []
     apis        = []
@@ -20,9 +22,30 @@ class OpalPlugin(object):
     head_extra  = []
     angular_module_deps = []
 
+    @classmethod
+    def get_urls(klass):
+        """
+        Return the urls
+        """
+        return klass.urls
+
+    @classmethod
+    def get_apis(klass):
+        """
+        Return the apis
+        """
+        return klass.apis
+
+    @classmethod
+    def directory(cls):
+        """
+        Give the plugins directory
+        """
+        return os.path.realpath(os.path.dirname(inspect.getfile(cls)))
+
     def flows(self):
         """
-        Return any extra flows our plugin may hav.e
+        Return any extra flows our plugin may have.
         """
         return {}
 
@@ -32,38 +55,14 @@ class OpalPlugin(object):
         """
         return {}
 
-    @classmethod
-    def directory(cls):
-        """
-        Give the plugins directory
-        """
-        return os.path.realpath(os.path.dirname(inspect.getfile(cls)))
 
-
-REGISTRY = set()
-AUTODISCOVERED = False
-
+# These two are only here for legacy reasons.
+# TODO: Consider removing and updating elsewhere.
 def register(what):
-    #print 'registering', what
-    REGISTRY.add(what)
-
-def autodiscover():
-    from opal.utils import stringport
-    global AUTODISCOVERED
-
-    for a in settings.INSTALLED_APPS:
-        stringport(a)
-    AUTODISCOVERED = True
-
-    return REGISTRY
+    pass
 
 def plugins():
     """
     Generator function for plugin instances
     """
-    global AUTODISCOVERED
-
-    if not AUTODISCOVERED:
-        autodiscover()
-    for m in REGISTRY:
-        yield m
+    return OpalPlugin.list()

--- a/opal/core/search/__init__.py
+++ b/opal/core/search/__init__.py
@@ -1,30 +1,5 @@
 """
 OPAL core search package
 """
-from opal.core.search import urls
-from opal.core import plugins
-
-
 from opal.core import celery  # NOQA
-
-
-class SearchPlugin(plugins.OpalPlugin):
-    """
-    The plugin entrypoint for OPAL's core search functionality
-    """
-    urls = urls.urlpatterns
-    javascripts = {
-        'opal.services': [
-            'js/search/services/filter.js',
-            'js/search/services/filters_loader.js',
-            'js/search/services/filter_resource.js',
-            "js/search/services/paginator.js",
-        ],
-        'opal.controllers': [
-            'js/search/controllers/search.js',
-            'js/search/controllers/extract.js',
-            "js/search/controllers/save_filter.js",
-        ]
-    }
-
-plugins.register(SearchPlugin)
+from opal.core.search import plugin

--- a/opal/core/search/plugin.py
+++ b/opal/core/search/plugin.py
@@ -22,5 +22,3 @@ class SearchPlugin(plugins.OpalPlugin):
             "js/search/controllers/save_filter.js",
         ]
     }
-
-plugins.register(SearchPlugin)

--- a/opal/core/search/plugin.py
+++ b/opal/core/search/plugin.py
@@ -1,0 +1,26 @@
+"""
+Plugin definition for opal.core.search
+"""
+from opal.core.search import urls
+from opal.core import plugins
+
+class SearchPlugin(plugins.OpalPlugin):
+    """
+    The plugin entrypoint for OPAL's core search functionality
+    """
+    urls = urls.urlpatterns
+    javascripts = {
+        'opal.services': [
+            'js/search/services/filter.js',
+            'js/search/services/filters_loader.js',
+            'js/search/services/filter_resource.js',
+            "js/search/services/paginator.js",
+        ],
+        'opal.controllers': [
+            'js/search/controllers/search.js',
+            'js/search/controllers/extract.js',
+            "js/search/controllers/save_filter.js",
+        ]
+    }
+
+plugins.register(SearchPlugin)

--- a/opal/models.py
+++ b/opal/models.py
@@ -1413,7 +1413,7 @@ class UserProfile(models.Model):
         Return a roles dictionary for this user
         """
         roles = {}
-        for plugin in plugins.plugins():
+        for plugin in plugins.OpalPlugin.list():
             roles.update(plugin().roles(self.user))
         roles['default'] = [r.name for r in self.roles.all()]
         return roles

--- a/opal/scaffolding/plugin_scaffold/app/__init__.py.jinja2
+++ b/opal/scaffolding/plugin_scaffold/app/__init__.py.jinja2
@@ -1,4 +1,3 @@
 """
 Package definition for the {{ name }} OPAL plugin
 """
-from {{ name }} import plugin

--- a/opal/scaffolding/plugin_scaffold/app/__init__.py.jinja2
+++ b/opal/scaffolding/plugin_scaffold/app/__init__.py.jinja2
@@ -1,42 +1,4 @@
 """
-Plugin definition for the {{ name }} OPAL plugin
+Package definition for the {{ name }} OPAL plugin
 """
-from opal.core import plugins
-
-from {{ name }}.urls import urlpatterns
-
-class {{ name.title() }}Plugin(plugins.OpalPlugin):
-    """
-    Main entrypoint to expose this plugin to our OPAL application.
-    """
-    urls = urlpatterns
-    javascripts = {
-        # Add your javascripts here!
-        'opal.{{ name }}': [
-            # 'js/{{ name }}/app.js',
-            # 'js/{{ name }}/controllers/larry.js',
-            # 'js/{{ name }}/services/larry.js',
-        ]
-    }
-    
-    def list_schemas(self):
-        """
-        Return any patient list schemas that our plugin may define.
-        """
-        return {}
-
-    def flows(self):
-        """
-        Return any custom flows that our plugin may define
-        """
-        return {}
-
-    def roles(self, user):
-        """
-        Given a (Django) USER object, return any extra roles defined
-        by our plugin.
-        """
-        return {}
-
-
-plugins.register({{ name.title() }}Plugin)
+from {{ name }} import plugin

--- a/opal/scaffolding/plugin_scaffold/app/plugin.py.jinja2
+++ b/opal/scaffolding/plugin_scaffold/app/plugin.py.jinja2
@@ -1,0 +1,42 @@
+"""
+Plugin definition for the {{ name }} OPAL plugin
+"""
+from opal.core import plugins
+
+from {{ name }}.urls import urlpatterns
+
+class {{ name.title() }}Plugin(plugins.OpalPlugin):
+    """
+    Main entrypoint to expose this plugin to our OPAL application.
+    """
+    urls = urlpatterns
+    javascripts = {
+        # Add your javascripts here!
+        'opal.{{ name }}': [
+            # 'js/{{ name }}/app.js',
+            # 'js/{{ name }}/controllers/larry.js',
+            # 'js/{{ name }}/services/larry.js',
+        ]
+    }
+
+    def list_schemas(self):
+        """
+        Return any patient list schemas that our plugin may define.
+        """
+        return {}
+
+    def flows(self):
+        """
+        Return any custom flows that our plugin may define
+        """
+        return {}
+
+    def roles(self, user):
+        """
+        Given a (Django) USER object, return any extra roles defined
+        by our plugin.
+        """
+        return {}
+
+
+plugins.register({{ name.title() }}Plugin)

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -45,7 +45,7 @@ def application_actions():
         app = application.get_app()
         for action in app.actions:
             yield action
-        for plugin in plugins.plugins():
+        for plugin in plugins.OpalPlugin.list():
             for action in plugin.actions:
                 yield action
     return dict(actions=actions)

--- a/opal/templatetags/plugins.py
+++ b/opal/templatetags/plugins.py
@@ -12,7 +12,7 @@ register = template.Library()
 @register.inclusion_tag('plugins/javascripts.html')
 def plugin_javascripts(namespace):
     def scripts():
-        for plugin in plugins.plugins():
+        for plugin in plugins.OpalPlugin.list():
             if namespace in plugin.javascripts:
                 for javascript in plugin.javascripts[namespace]:
                     yield javascript
@@ -21,7 +21,7 @@ def plugin_javascripts(namespace):
 @register.inclusion_tag('plugins/stylesheets.html')
 def plugin_stylesheets():
     def styles():
-        for plugin in plugins.plugins():
+        for plugin in plugins.OpalPlugin.list():
             for sheet in plugin.stylesheets:
                 yield sheet
     return dict(styles=styles)
@@ -29,7 +29,7 @@ def plugin_stylesheets():
 @register.inclusion_tag('plugins/head_extra.html', takes_context=True)
 def plugin_head_extra(context):
     def templates():
-        for plugin in plugins.plugins():
+        for plugin in plugins.OpalPlugin.list():
             for tpl in plugin.head_extra:
                     yield tpl
     ctx = context
@@ -48,7 +48,7 @@ def sort_menu_items(items):
 @register.inclusion_tag('plugins/menuitems.html')
 def plugin_menuitems():
     def items():
-        for plugin in plugins.plugins():
+        for plugin in plugins.OpalPlugin.list():
             for i in plugin.menuitems:
                 yield i
 
@@ -57,7 +57,7 @@ def plugin_menuitems():
 @register.inclusion_tag('plugins/angular_module_deps.html')
 def plugin_opal_angular_deps():
     def deps():
-        for plugin in plugins.plugins():
+        for plugin in plugins.OpalPlugin.list():
             for i in plugin.angular_module_deps:
                 yield i
     return dict(deps=deps)
@@ -66,7 +66,7 @@ def plugin_opal_angular_deps():
 def plugin_opal_angular_tracking_exclude():
     def yield_property(property_name):
         app = application.get_app()
-        app_and_plugins = itertools.chain(plugins.plugins(), [app])
+        app_and_plugins = itertools.chain(plugins.OpalPlugin.list(), [app])
 
         for plugin in app_and_plugins:
             excluded_tracking_prefixes = getattr(plugin, property_name, [])

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -780,7 +780,7 @@ class PatientListTestCase(TestCase):
 
 class RegisterPluginsTestCase(OpalTestCase):
 
-    @patch('opal.core.api.plugins.plugins')
+    @patch('opal.core.api.plugins.OpalPlugin.list')
     def test_register(self, plugins):
         mock_plugin = MagicMock(name='Mock Plugin')
         mock_plugin.get_apis.return_value = [('thingapi', None)]

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -783,7 +783,7 @@ class RegisterPluginsTestCase(OpalTestCase):
     @patch('opal.core.api.plugins.plugins')
     def test_register(self, plugins):
         mock_plugin = MagicMock(name='Mock Plugin')
-        mock_plugin.apis = [('thingapi', None)]
+        mock_plugin.get_apis.return_value = [('thingapi', None)]
         plugins.return_value = [mock_plugin]
         with patch.object(api.router, 'register') as register:
             api.register_plugin_apis()

--- a/opal/tests/test_core_application.py
+++ b/opal/tests/test_core_application.py
@@ -65,7 +65,7 @@ class GetAppTestCase(TestCase):
 
 class GetAllComponentsTestCase(TestCase):
     @patch('opal.core.application.OpalApplication.__subclasses__')
-    @patch('opal.core.plugins.plugins')
+    @patch('opal.core.plugins.OpalPlugin.list')
     def test_get_app(self, plugins, subclasses):
         mock_app = MagicMock('Mock App')
         plugin = MagicMock()

--- a/opal/tests/test_core_plugins.py
+++ b/opal/tests/test_core_plugins.py
@@ -30,3 +30,14 @@ class RegisterPluginsTestCase(OpalTestCase):
             assert len(w) == 1
             assert issubclass(w[-1].category, DeprecationWarning)
             assert "no longer required" in str(w[-1].message)
+
+
+class PluginsPluginsTestCase(OpalTestCase):
+
+    def test_plugins_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            plugins.plugins()
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert "slated for removal" in str(w[-1].message)

--- a/opal/tests/test_core_plugins.py
+++ b/opal/tests/test_core_plugins.py
@@ -1,11 +1,14 @@
 """
 Unittests for opal.core.plugins
 """
-from mock import patch
-from opal.core.test import OpalTestCase
-from opal.core import plugins
-from opal.tests.test_templatetags_plugins import TestPlugin
+import warnings
 
+from mock import patch
+
+from opal.core.test import OpalTestCase
+
+from opal.tests.test_templatetags_plugins import TestPlugin
+from opal.core import plugins
 
 class OpalPluginTestCase(OpalTestCase):
     def test_flows(self):
@@ -14,5 +17,16 @@ class OpalPluginTestCase(OpalTestCase):
     @patch("opal.core.plugins.inspect.getfile")
     def test_directory(self, getfile):
         getfile.return_value = "/"
-        plugin = list(plugins.plugins())[0]
+        plugin = list(plugins.OpalPlugin.list())[0]
         self.assertEqual(plugin.directory(), "/")
+
+
+class RegisterPluginsTestCase(OpalTestCase):
+
+    def test_register_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            plugins.register(None)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert "no longer required" in str(w[-1].message)

--- a/opal/tests/test_scaffold.py
+++ b/opal/tests/test_scaffold.py
@@ -350,3 +350,19 @@ class RecordRenderTestCase(OpalTestCase):
         lshift.assert_called_once_with(
             '<span ng-show="item.name">\n     Name\n   <br />\n</span>'
         )
+
+    @patch('ffs.Path.__nonzero__')
+    @patch('ffs.Path.mkdir')
+    @patch.object(Colour, "build_field_schema")
+    def test_makes_records_dir_if_does_not_exist(self, build_field_schema, mkdir, nonzero, lshift):
+        build_field_schema.return_value = {
+            'lookup_list': None,
+            'model': 'Colour',
+            'name': 'name',
+            'title': 'Name',
+            'type': 'null_boolean'
+        },
+        nonzero.return_value = False
+        scaffold_path = ffs.Path(settings.PROJECT_PATH)/'scaffolding'
+        create_display_template_for(Colour, scaffold_path)
+        mkdir.assert_called_once_with()

--- a/opal/tests/test_scaffold.py
+++ b/opal/tests/test_scaffold.py
@@ -351,10 +351,11 @@ class RecordRenderTestCase(OpalTestCase):
             '<span ng-show="item.name">\n     Name\n   <br />\n</span>'
         )
 
+    @patch('ffs.Path.__bool__')
     @patch('ffs.Path.__nonzero__')
     @patch('ffs.Path.mkdir')
     @patch.object(Colour, "build_field_schema")
-    def test_makes_records_dir_if_does_not_exist(self, build_field_schema, mkdir, nonzero, lshift):
+    def test_makes_records_dir_if_does_not_exist(self, build_field_schema, mkdir, nonzero, booler, lshift):
         build_field_schema.return_value = {
             'lookup_list': None,
             'model': 'Colour',
@@ -362,7 +363,11 @@ class RecordRenderTestCase(OpalTestCase):
             'title': 'Name',
             'type': 'null_boolean'
         },
+
+        # We need both of these to make sure this works on both Python3 and Python2
         nonzero.return_value = False
+        booler.return_value = False
+
         scaffold_path = ffs.Path(settings.PROJECT_PATH)/'scaffolding'
         create_display_template_for(Colour, scaffold_path)
         mkdir.assert_called_once_with()

--- a/opal/tests/test_templatetags_application.py
+++ b/opal/tests/test_templatetags_application.py
@@ -66,7 +66,7 @@ class ApplicationStylesTestCase(OpalTestCase):
 
 class ApplicatoinActionsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.application.plugins.plugins')
+    @patch('opal.templatetags.application.plugins.OpalPlugin.list')
     @patch('opal.templatetags.application.application.get_app')
     def test_application_actions(self, get_app, get_plugins):
         mock_app = MagicMock(name='Application')

--- a/opal/tests/test_templatetags_plugins.py
+++ b/opal/tests/test_templatetags_plugins.py
@@ -19,7 +19,7 @@ class TestPlugin(plugins.OpalPlugin):
 
 class PluginJavascriptsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.plugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.OpalPlugin.list')
     def test_plugin_javascripts(self, plugins):
         plugins.return_value = [TestPlugin]
         result = opalplugins.plugin_javascripts('opal.test')
@@ -32,7 +32,7 @@ class PluginJavascriptsTestCase(OpalTestCase):
 
 class PluginStylesheetsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.plugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.OpalPlugin.list')
     def test_plugin_stylesheets(self, plugins):
         plugins.return_value = [TestPlugin]
         css = list(opalplugins.plugin_stylesheets()['styles']())
@@ -41,7 +41,7 @@ class PluginStylesheetsTestCase(OpalTestCase):
 
 class PluginHeadExtraTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.plugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.OpalPlugin.list')
     def test_plugin_head_extra(self, plugins):
         plugins.return_value = [TestPlugin]
         context = opalplugins.plugin_head_extra({})
@@ -62,7 +62,7 @@ class MenuItemOrderingTest(OpalTestCase):
 
 class PluginMenuitemsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.plugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.OpalPlugin.list')
     def test_plugin_menuitems(self, plugins):
         plugins.return_value = [TestPlugin]
         menuitems = opalplugins.plugin_menuitems()['items']
@@ -72,7 +72,7 @@ class PluginMenuitemsTestCase(OpalTestCase):
 
 class PluginAngularDepsTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.plugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.OpalPlugin.list')
     def test_plugin_angular_deps(self, plugins):
         plugins.return_value = [TestPlugin]
         deps = list(opalplugins.plugin_opal_angular_deps()['deps']())
@@ -81,7 +81,7 @@ class PluginAngularDepsTestCase(OpalTestCase):
 
 class PluginOPALAngularTrackingExcludeTestCase(OpalTestCase):
 
-    @patch('opal.templatetags.plugins.plugins.plugins')
+    @patch('opal.templatetags.plugins.plugins.OpalPlugin.list')
     def test_prefixes(self, plugins):
         plugins.return_value = [TestPlugin]
         expected_prefix = []

--- a/opal/urls.py
+++ b/opal/urls.py
@@ -88,7 +88,7 @@ urlpatterns += staticfiles_urlpatterns()
 from opal.core import plugins
 
 for plugin in plugins.plugins():
-    urlpatterns += plugin.urls
+    urlpatterns += plugin.get_urls()
 
 urlpatterns += patterns(
     '',

--- a/opal/urls.py
+++ b/opal/urls.py
@@ -87,7 +87,7 @@ urlpatterns += staticfiles_urlpatterns()
 
 from opal.core import plugins
 
-for plugin in plugins.plugins():
+for plugin in plugins.OpalPlugin.list():
     urlpatterns += plugin.get_urls()
 
 urlpatterns += patterns(


### PR DESCRIPTION
Plugins should be discoverable features.

This PR should be backwards compatible with all plugins, and enables the work of converting individual plugins to move into `plugins.py` and remove e.g. calls to `plugins.register()`.

The interesting thing here is the `warnings.warn` part, which is new for us...

refs #731 