### PR TITLE
first run of sass

### DIFF
--- a/opal/scaffolding/scaffold/app/settings.py.jinja2
+++ b/opal/scaffolding/scaffold/app/settings.py.jinja2
@@ -264,6 +264,11 @@ REST_FRAMEWORK = {
     )
 }
 
+# if you want sass, uncomment the below and gem install sass
+# COMPRESS_PRECOMPILERS = (
+#     ('text/x-scss', 'sass --scss {infile} {outfile}'),
+# )
+
 try:
     from local_settings import *
 except:

--- a/opal/templates/opal.html
+++ b/opal/templates/opal.html
@@ -81,15 +81,16 @@
     <link href="{% static "css/ngprogress-lite.css" %}" rel="stylesheet" media="screen">
 	<link href="{% static "js/lib/bower_components/angular-growl-v2/build/angular-growl.css" %}" rel="stylesheet" media="screen">
 
-    {% compress css %}
 
-	<link href="{% static "css/opal.css" %}" rel="stylesheet" media="all">
-    {% endcompress %}
     <link href="{% static "css/print.css" %}" rel="stylesheet" media="print">
     <link href="{% static "css/screen.css" %}" rel="stylesheet" media="screen">
 
-    {% plugin_stylesheets %}
-    {% application_stylesheets %}
+    {% compress css %}
+    	<link href="{% static "css/opal.css" %}" rel="stylesheet" media="all">
+      {% plugin_stylesheets %}
+      {% application_stylesheets %}
+    {% endcompress %}
+
 
     <link rel="shortcut icon" href="{% static 'img/ohc-icon.png' %}">
 

--- a/opal/templates/plugins/stylesheets.html
+++ b/opal/templates/plugins/stylesheets.html
@@ -1,4 +1,4 @@
 {% load staticfiles %}
-{% for sheet in styles %}
-<link href="{% static sheet  %}" rel="stylesheet" media="screen">
+{% for sheet, mime_type in styles %}
+<link href="{% static sheet  %}" type="{{ mime_type }}" rel="stylesheet" charset="utf-8" media="screen">
 {% endfor %}

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -36,7 +36,11 @@ def application_stylesheets():
     def styles():
         app = application.get_app()
         for style in app.get_styles():
-            yield style
+            if style.endswith(".scss"):
+                mime_type = "text/x-scss"
+            else:
+                mime_type = "text/css"
+            yield style, mime_type
     return dict(styles=styles)
 
 @register.inclusion_tag('plugins/actions.html')

--- a/opal/tests/test_templatetags_application.py
+++ b/opal/tests/test_templatetags_application.py
@@ -53,14 +53,25 @@ class ApplicationJavascriptTestCase(OpalTestCase):
 class ApplicationStylesTestCase(OpalTestCase):
 
     @patch('opal.templatetags.application.application.get_app')
-    def test_core_styles(self, get_app):
+    def test_core_styles_with_css(self, get_app):
         mock_app = MagicMock(name='Application')
         mock_app.get_styles.return_value = ['test.css']
         get_app.return_value = mock_app
 
         result = list(application.application_stylesheets()['styles']())
 
-        self.assertEqual(['test.css'], result)
+        self.assertEqual([("test.css", "text/css",)], result)
+        mock_app.get_styles.assert_called_with()
+
+    @patch('opal.templatetags.application.application.get_app')
+    def test_core_styles_with_scss(self, get_app):
+        mock_app = MagicMock(name='Application')
+        mock_app.get_styles.return_value = ['test.scss']
+        get_app.return_value = mock_app
+
+        result = list(application.application_stylesheets()['styles']())
+
+        self.assertEqual([("test.scss", "text/x-scss",)], result)
         mock_app.get_styles.assert_called_with()
 
 


### PR DESCRIPTION
so... this doesn't go far enough probably...

I think there's another stage to move opal into an scss file but this, currently will allow all our applications that run sass to do sass nice and easy.

stage 2, figure out if there's a reason we don't compress the bootstrap.css in our app
stage 3, move our use of opal to an opal.scss file in a way the variables are easily overridable
stage 4, move to bootstrap sass