### PR TITLE
Users for menuitems

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+# -*- mode: conf -*-
+[flake8]
+ignore  = E203,E221
+exclude = migrations,opal/tests,node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,21 @@
 ### 0.8.1 (Minor Release)
 
-### PatientList.get_queryset arguments
+#### PatientList.get_queryset arguments
 
-PatientList.get_queryset() is passed an extra keyword argument - `user`.
+PatientList.get_queryset() is now passed an extra keyword argument - `user`.
 This is the current `User` object.
 
 #### Removed Subrecord._bulk_serialise
 
 This flag no longer exists
+
+#### Overriding default Menu Items behaviour
+
+The `get_menu_items` method of Opal Application objects is now passed an extra keyword argument - `user`.
+This is the current `User` object.
+
+The templatetag application_menuitems now uses this method to render navigation menus, allowing dynamic
+customisation of menu contents based on user.
 
 
 ### 0.8.0 (Major Release)

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,6 +1,6 @@
 ## Opal Documentation
 
-#### Opal is a full stack framework that makes building digital tools for health care easy.
+_Opal is a full stack framework that makes building digital tools for health care easy._
 
 Opal builds deep clinical domain specific functionality on top of
 [Django](https://djangoproject.com/), [Angular](https://angularjs.org/)

--- a/doc/docs/reference/opal_application.md
+++ b/doc/docs/reference/opal_application.md
@@ -83,7 +83,10 @@ application.get_javascripts()
 
 Returns the file system location of the module.
 
-#### OpalApplication.get_menu_items()
+#### OpalApplication.get_menu_items(user=None)
+
+Hook to customise the visibility of menu items to e.g. restrict some based on the current
+user.
 
 #### OpalApplication.get_styles()
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -67,7 +67,7 @@ dev_addr: 0.0.0.0:8965
 include_next_prev: false
 
 extra:
-  version: v0.8.0
+  version: v0.8.1
 
 markdown_extensions:
     - fenced_code

--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -1,5 +1,5 @@
 """
-Application helpers for OPAL
+Application helpers for Opal
 """
 import inspect
 import os

--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -33,7 +33,7 @@ class OpalApplication(object):
             # "js/ui-select/dist/select.js",
             "js/lib/bower_components/angular-ui-select/dist/select.js",
             "js/lib/bower_components/ng-idle/angular-idle.js",
-            "js/lib/bower_components/angular-local-storage/dist/angular-local-storage.js",
+            "js/lib/bower_components/angular-local-storage/dist/angular-local-storage.js",  # noqa: E501
             "js/lib/bower_components/ment.io/dist/templates.js",
             "js/lib/bower_components/angular-growl-v2/build/angular-growl.js",
             "js/lib/jquery-plugins/idle-timer.js",
@@ -139,6 +139,7 @@ class OpalApplication(object):
         Return the filesystem path to the app directory
         """
         return os.path.realpath(os.path.dirname(inspect.getfile(cls)))
+
 
 def get_app():
     """

--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -117,7 +117,7 @@ class OpalApplication(object):
         return klass.javascripts
 
     @classmethod
-    def get_menu_items(klass):
+    def get_menu_items(klass, user=None):
         """
         Default implementation of get_menu_items()
 

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -8,11 +8,11 @@ from opal.core import application, plugins
 register = template.Library()
 
 
-@register.inclusion_tag('plugins/menuitems.html')
-def application_menuitems():
+@register.inclusion_tag('plugins/menuitems.html', takes_context=True)
+def application_menuitems(context):
     def items():
         app = application.get_app()
-        for i in app.menuitems:
+        for i in app.get_menu_items(user=context['request'].user):
             yield i
     return dict(items=items)
 

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -12,7 +12,7 @@ register = template.Library()
 def application_menuitems(context):
     def items():
         app = application.get_app()
-        for i in app.get_menu_items(user=context['request'].user):
+        for i in app.get_menu_items(user=context['user']):
             yield i
     return dict(items=items)
 

--- a/opal/templatetags/application.py
+++ b/opal/templatetags/application.py
@@ -1,5 +1,5 @@
 """
-Templatetags for working with OPAL applications
+Templatetags for working with Opal applications
 """
 from django import template
 

--- a/opal/tests/test_core_application.py
+++ b/opal/tests/test_core_application.py
@@ -1,15 +1,16 @@
 """
 Unittests for opal.core.application
 """
-from django.test import TestCase
 from mock import patch, MagicMock
+
+from opal.core.test import OpalTestCase
 
 from opal.core import application
 
-class OpalApplicationTestCase(TestCase):
+class OpalApplicationTestCase(OpalTestCase):
+
     def setUp(self):
         class App(application.OpalApplication):
-            flow_module = 'opal.tests.flows'
             javascripts = ['test.js']
             styles = ['app.css']
 
@@ -46,6 +47,11 @@ class OpalApplicationTestCase(TestCase):
             [],
             application.OpalApplication.get_menu_items())
 
+    def test_get_menu_items_takes_user(self):
+        self.assertEqual(
+            [],
+            application.OpalApplication.get_menu_items(user=self.user))
+
     def test_get_styles(self):
         self.assertEqual(['app.css'], self.app.get_styles())
 
@@ -55,7 +61,8 @@ class OpalApplicationTestCase(TestCase):
         self.assertEqual(application.OpalApplication.directory(), "/")
 
 
-class GetAppTestCase(TestCase):
+class GetAppTestCase(OpalTestCase):
+
     @patch('opal.core.application.OpalApplication.__subclasses__')
     def test_get_app(self, subclasses):
         mock_app = MagicMock('Mock App')
@@ -63,7 +70,8 @@ class GetAppTestCase(TestCase):
         self.assertEqual(mock_app, application.get_app())
 
 
-class GetAllComponentsTestCase(TestCase):
+class GetAllComponentsTestCase(OpalTestCase):
+
     @patch('opal.core.application.OpalApplication.__subclasses__')
     @patch('opal.core.plugins.OpalPlugin.list')
     def test_get_app(self, plugins, subclasses):

--- a/opal/tests/test_templatetags_application.py
+++ b/opal/tests/test_templatetags_application.py
@@ -15,11 +15,23 @@ class ApplicationMenuitemsTestCase(OpalTestCase):
     @patch('opal.templatetags.application.application.get_app')
     def test_application_menuitems(self, get_app):
         mock_app = MagicMock(name='Application')
-        mock_app.menuitems = [{'display': 'test'}]
+        mock_app.get_menu_items.return_value = [{'display': 'test'}]
         get_app.return_value = mock_app
-        result = list(application.application_menuitems()['items']())
+        ctx = MagicMock(name='Context')
+        result = list(application.application_menuitems(ctx)['items']())
         expected = [{'display': 'test'}]
         self.assertEqual(expected, result)
+
+    @patch('opal.templatetags.application.application.get_app')
+    def test_application_menuitems_passes_through_user(self, get_app):
+        mock_app = MagicMock(name='Application')
+        mock_user = MagicMock(name='User')
+        mock_request = MagicMock(name='Request')
+        mock_request.user = mock_user
+        context = {'request': mock_request}
+        get_app.return_value = mock_app
+        result = list(application.application_menuitems(context)['items']())
+        mock_app.get_menu_items.assert_called_with(user=mock_user)
 
 
 class CoreJavascriptTestCase(OpalTestCase):

--- a/opal/tests/test_templatetags_application.py
+++ b/opal/tests/test_templatetags_application.py
@@ -26,11 +26,9 @@ class ApplicationMenuitemsTestCase(OpalTestCase):
     def test_application_menuitems_passes_through_user(self, get_app):
         mock_app = MagicMock(name='Application')
         mock_user = MagicMock(name='User')
-        mock_request = MagicMock(name='Request')
-        mock_request.user = mock_user
-        context = {'request': mock_request}
+        context = {'user': mock_user}
         get_app.return_value = mock_app
-        result = list(application.application_menuitems(context)['items']())
+        list(application.application_menuitems(context)['items']())
         mock_app.get_menu_items.assert_called_with(user=mock_user)
 
 


### PR DESCRIPTION
To allow filtering of Application menu items by user we need to pass the user into the `get_menu_items` method.

Also does some minor formatting and adds a Flake8 config that ignores some paths and Error classes.