### PR TITLE
Refactor opal.core.api to use json_response consistently. This ensure…

### DIFF
--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -142,7 +142,8 @@ class ReferenceDataViewSet(LoginRequiredViewset):
             return json_response(values)
 
         return json_response(
-            {'error': 'Item does not exist'}, status_code=status.HTTP_404_NOT_FOUND
+            {'error': 'Item does not exist'},
+            status_code=status.HTTP_404_NOT_FOUND
         )
 
 
@@ -216,7 +217,7 @@ class SubrecordViewSet(LoginRequiredViewset):
             item.update_from_dict(request.data, request.user)
         except exceptions.APIError:
             return json_response({'error': 'Unexpected field name'},
-                            status_code=status.HTTP_400_BAD_REQUEST)
+                                 status_code=status.HTTP_400_BAD_REQUEST)
         except exceptions.ConsistencyError:
             return json_response(
                 {'error': 'Item has changed'},

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -4,7 +4,6 @@ Public facing API views
 from django.shortcuts import get_object_or_404
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import routers, status, viewsets
-from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from opal.models import (
@@ -40,9 +39,9 @@ def item_from_pk(fn):
         try:
             item = self.model.objects.get(pk=pk)
         except self.model.DoesNotExist:
-            return Response(
+            return json_response(
                 {'error': 'Item does not exist'},
-                status=status.HTTP_404_NOT_FOUND
+                status_code=status.HTTP_404_NOT_FOUND
             )
         return fn(self, request, item)
     return get_item
@@ -56,9 +55,9 @@ def episode_from_pk(fn):
         try:
             return fn(self, request, Episode.objects.get(pk=pk))
         except Episode.DoesNotExist:
-            return Response(
+            return json_response(
                 {'error': 'Episode does not exist'},
-                status=status.HTTP_404_NOT_FOUND
+                status_code=status.HTTP_404_NOT_FOUND
             )
     return get_item
 
@@ -85,7 +84,7 @@ class RecordViewSet(LoginRequiredViewset):
     base_name = 'record'
 
     def list(self, request):
-        return Response(schemas.list_records())
+        return json_response(schemas.list_records())
 
 
 class ExtractSchemaViewSet(LoginRequiredViewset):
@@ -95,7 +94,7 @@ class ExtractSchemaViewSet(LoginRequiredViewset):
     base_name = 'extract-schema'
 
     def list(self, request):
-        return Response(schemas.extract_schema())
+        return json_response(schemas.extract_schema())
 
 
 class ReferenceDataViewSet(LoginRequiredViewset):
@@ -123,7 +122,7 @@ class ReferenceDataViewSet(LoginRequiredViewset):
 
         for name in data:
             data[name].sort()
-        return Response(data)
+        return json_response(data)
 
     def retrieve(self, request, pk=None):
         the_list = None
@@ -140,10 +139,10 @@ class ReferenceDataViewSet(LoginRequiredViewset):
                 'name', flat=True
             )
             values += list(synonyms)
-            return Response(values)
+            return json_response(values)
 
-        return Response(
-            {'error': 'Item does not exist'}, status=status.HTTP_404_NOT_FOUND
+        return json_response(
+            {'error': 'Item does not exist'}, status_code=status.HTTP_404_NOT_FOUND
         )
 
 
@@ -157,16 +156,16 @@ class MetadataViewSet(LoginRequiredViewset):
         data = {}
         for meta in metadata.Metadata.list():
             data.update(meta.to_dict(user=request.user))
-        return Response(data)
+        return json_response(data)
 
     def retrieve(self, request, pk=None):
         try:
             meta = metadata.Metadata.get(pk)
-            return Response(meta.to_dict(user=request.user))
+            return json_response(meta.to_dict(user=request.user))
         except ValueError:
-            return Response(
+            return json_response(
                 {'error': 'Metadata does not exist'},
-                status=status.HTTP_404_NOT_FOUND
+                status_code=status.HTTP_404_NOT_FOUND
             )
 
 
@@ -190,8 +189,8 @@ class SubrecordViewSet(LoginRequiredViewset):
         try:
             episode = Episode.objects.get(pk=request.data['episode_id'])
         except Episode.DoesNotExist:
-            return Response(
-                'Nonexistant episode', status=status.HTTP_400_BAD_REQUEST
+            return json_response(
+                'Nonexistant episode', status_code=status.HTTP_400_BAD_REQUEST
             )
 
         if isinstance(subrecord, PatientSubrecord):
@@ -209,19 +208,19 @@ class SubrecordViewSet(LoginRequiredViewset):
 
     @item_from_pk
     def retrieve(self, request, item):
-        return Response(item.to_dict(request.user))
+        return json_response(item.to_dict(request.user))
 
     @item_from_pk
     def update(self, request, item):
         try:
             item.update_from_dict(request.data, request.user)
         except exceptions.APIError:
-            return Response({'error': 'Unexpected field name'},
-                            status=status.HTTP_400_BAD_REQUEST)
+            return json_response({'error': 'Unexpected field name'},
+                            status_code=status.HTTP_400_BAD_REQUEST)
         except exceptions.ConsistencyError:
-            return Response(
+            return json_response(
                 {'error': 'Item has changed'},
-                status=status.HTTP_409_CONFLICT
+                status_code=status.HTTP_409_CONFLICT
             )
         return json_response(
             item.to_dict(request.user),
@@ -231,7 +230,7 @@ class SubrecordViewSet(LoginRequiredViewset):
     @item_from_pk
     def destroy(self, request, item):
         item.delete()
-        return Response('deleted', status=status.HTTP_202_ACCEPTED)
+        return json_response('deleted', status_code=status.HTTP_202_ACCEPTED)
 
 
 class UserProfileViewSet(LoginRequiredViewset):
@@ -242,7 +241,7 @@ class UserProfileViewSet(LoginRequiredViewset):
 
     def list(self, request):
         profile = request.user.profile
-        return Response(profile.to_dict())
+        return json_response(profile.to_dict())
 
 
 class TaggingViewSet(LoginRequiredViewset):
@@ -253,9 +252,9 @@ class TaggingViewSet(LoginRequiredViewset):
 
     @episode_from_pk
     def retrieve(self, request, episode):
-        return Response(
+        return json_response(
             episode.tagging_dict(request.user)[0],
-            status=status.HTTP_200_OK
+            status_code=status.HTTP_200_OK
         )
 
     @episode_from_pk
@@ -264,9 +263,9 @@ class TaggingViewSet(LoginRequiredViewset):
             del request.data['id']
         tag_names = [n for n, v in list(request.data.items()) if v]
         episode.set_tag_names(tag_names, request.user)
-        return Response(
+        return json_response(
             episode.tagging_dict(request.user)[0],
-            status=status.HTTP_202_ACCEPTED
+            status_code=status.HTTP_202_ACCEPTED
         )
 
 
@@ -361,9 +360,9 @@ class PatientListViewSet(LoginRequiredViewset):
         try:
             patientlist = PatientList.get(pk)()
         except ValueError:
-            return Response(
+            return json_response(
                 {'error': 'List does not exist'},
-                status=status.HTTP_404_NOT_FOUND
+                status_code=status.HTTP_404_NOT_FOUND
             )
         return json_response(patientlist.to_dict(request.user))
 

--- a/opal/core/views.py
+++ b/opal/core/views.py
@@ -49,6 +49,7 @@ def json_response(data, status_code=200):
     """
     response = HttpResponse()
     response['Content-Type'] = 'application/json'
+    response.data = data
     response.content = json.dumps(data, cls=OpalSerializer)
     response.status_code = status_code
     return response


### PR DESCRIPTION
…s that we will always use the OpalSerializer and that we don't have to decide which to use in opal.core.api - we can follow the convention of the code around us.