### PR TITLE
Future API removals should probably be warnings not errors

### DIFF
--- a/opal/static/js/opal/services/metadata.js
+++ b/opal/static/js/opal/services/metadata.js
@@ -34,7 +34,7 @@ angular.module('opal.services').factory('Metadata', function($q, $http, $window,
       load: load,
       then: function(fn){
         // TODO: 0.9.0
-        $log.error("This API is being deprecated and will be removed in 0.9.0. Please use Metadata.load()");
+        $log.warn("This API is being deprecated and will be removed in 0.9.0. Please use Metadata.load()");
         load().then(function(result){ fn(result); });
       }
     };

--- a/opal/static/js/opal/services/record_loader.js
+++ b/opal/static/js/opal/services/record_loader.js
@@ -18,7 +18,7 @@ angular.module('opal.services')
     load: load,
     then: function(fn){
       // TODO: 0.9.0
-      $log.error("This API is being deprecated and will be removed in 0.9.0. Please use recordLoader.load()");
+      $log.warn("This API is being deprecated and will be removed in 0.9.0. Please use recordLoader.load()");
       load().then(function(result){ fn(result); });
     }
   };

--- a/opal/static/js/opal/services/referencedata.js
+++ b/opal/static/js/opal/services/referencedata.js
@@ -53,7 +53,7 @@ angular.module('opal.services').factory('Referencedata', function($q, $http, $wi
       load: load,
       then: function(fn){
         // TODO: 0.9.0
-        $log.error("This API is being deprecated and will be removed in 0.9.0. Please use Referencedata.load()");
+        $log.warn("This API is being deprecated and will be removed in 0.9.0. Please use Referencedata.load()");
         load().then(function(result){ fn(result); });
       }
     };

--- a/opal/static/js/opal/services/user_profile.js
+++ b/opal/static/js/opal/services/user_profile.js
@@ -58,7 +58,7 @@ angular.module('opal.services')
           load: load,
           then: function(fn){
             // TODO: 0.9.0
-            $log.error("This API is being deprecated and will be removed in 0.9.0. Please use UserProfile.load()");
+            $log.warn("This API is being deprecated and will be removed in 0.9.0. Please use UserProfile.load()");
             load().then(function(result){ fn(result); });
           }
         };

--- a/opal/static/js/test/metadata.service.test.js
+++ b/opal/static/js/test/metadata.service.test.js
@@ -20,7 +20,7 @@ describe('Metadata', function(){
             $provide.value('$window', mock);
         });
 
-        $log = jasmine.createSpyObj(['error']);
+        $log = jasmine.createSpyObj(['warn']);
 
         inject(function($injector){
             Metadata       = $injector.get('Metadata');
@@ -28,7 +28,7 @@ describe('Metadata', function(){
             $rootScope     = $injector.get('$rootScope');
             $log = $injector.get('$log');
         });
-        spyOn($log, "error");
+        spyOn($log, "warn");
     });
 
     afterEach(function(){
@@ -44,7 +44,7 @@ describe('Metadata', function(){
         $rootScope.$apply();
         $httpBackend.flush();
         expect(result.get('foo')).toEqual('bar');
-        expect($log.error).toHaveBeenCalledWith(
+        expect($log.warn).toHaveBeenCalledWith(
           'This API is being deprecated and will be removed in 0.9.0. Please use Metadata.load()'
         );
     });

--- a/opal/static/js/test/recordLoader.service.test.js
+++ b/opal/static/js/test/recordLoader.service.test.js
@@ -29,7 +29,7 @@ describe('recordLoader', function(){
             $rootScope     = $injector.get('$rootScope');
             $log = $injector.get('$log');
         });
-        spyOn($log, "error");
+        spyOn($log, "warn");
     });
 
     it('then should call through to load', function(){
@@ -41,7 +41,7 @@ describe('recordLoader', function(){
         $httpBackend.flush();
         expect(result).toEqual(recordSchema);
         expect($rootScope.fields).toEqual(recordSchema);
-        expect($log.error).toHaveBeenCalledWith(
+        expect($log.warn).toHaveBeenCalledWith(
           'This API is being deprecated and will be removed in 0.9.0. Please use recordLoader.load()'
         );
     });

--- a/opal/static/js/test/referencedata.service.test.js
+++ b/opal/static/js/test/referencedata.service.test.js
@@ -28,7 +28,7 @@ describe('Referencedata', function(){
             $rootScope     = $injector.get('$rootScope');
             $log = $injector.get('$log');
         });
-        spyOn($log, "error");
+        spyOn($log, "warn");
     });
 
     it('then should call through to load', function(){
@@ -39,7 +39,7 @@ describe('Referencedata', function(){
         $rootScope.$apply();
         $httpBackend.flush();
         expect(result.get('foo')).toEqual(['bar']);
-        expect($log.error).toHaveBeenCalledWith(
+        expect($log.warn).toHaveBeenCalledWith(
           'This API is being deprecated and will be removed in 0.9.0. Please use Referencedata.load()'
         );
     });

--- a/opal/static/js/test/user_profile.service.test.js
+++ b/opal/static/js/test/user_profile.service.test.js
@@ -23,7 +23,7 @@ describe('UserProfile', function(){
             $routeParams   = $injector.get('$routeParams');
             $log = $injector.get('$log');
         });
-        spyOn($log, "error");
+        spyOn($log, "warn");
     });
 
     it('then should call through to load', function(){
@@ -34,7 +34,7 @@ describe('UserProfile', function(){
         $rootScope.$apply();
         $httpBackend.flush();
         expect(result.roles.tropical).toEqual(result.roles.tropical);
-        expect($log.error).toHaveBeenCalledWith(
+        expect($log.warn).toHaveBeenCalledWith(
           'This API is being deprecated and will be removed in 0.9.0. Please use UserProfile.load()'
         );
     });


### PR DESCRIPTION
Let's alter the level of the JS API removal notices