### PR TITLE
Add a new opal.config module

### DIFF
--- a/opal/static/js/opal/app.js
+++ b/opal/static/js/opal/app.js
@@ -1,6 +1,7 @@
 var app = OPAL.module('opal', [
     'ngRoute',
     'ngProgressLite',
+    'opal.config',
   	'opal.filters',
   	'opal.services',
   	'opal.directives',

--- a/opal/static/js/opal/services/flow.js
+++ b/opal/static/js/opal/services/flow.js
@@ -3,33 +3,36 @@ angular.module(
 ).factory(
     'Flow',
     function($q, $http, $modal, $cacheFactory, $injector){
-        var ApplicationFlow;
-
-        if(OPAL_FLOW_SERVICE){
-            ApplicationFlow = $injector.get(OPAL_FLOW_SERVICE);
-        }else{
-            ApplicationFlow = {
-                enter:  function(){
-                    return {
-                    'controller': 'HospitalNumberCtrl',
-                    'template'  : '/templates/modals/hospital_number.html/'
-                  };
-                },
-                exit: function(){
-                    return  {
-                    'controller': 'DischargeEpisodeCtrl',
-                    'template'  : '/templates/modals/discharge_episode.html/'
-                  };
-                }
-            };
+        "use strict";
+        var get_flow_service = function(){
+            var OPAL_FLOW_SERVICE = $injector.get('OPAL_FLOW_SERVICE');
+            if(OPAL_FLOW_SERVICE){
+                return $injector.get(OPAL_FLOW_SERVICE);
+            }else{
+                return {
+                    enter:  function(){
+                        return {
+                            'controller': 'HospitalNumberCtrl',
+                            'template'  : '/templates/modals/hospital_number.html/'
+                        };
+                    },
+                    exit: function(){
+                        return  {
+                            'controller': 'DischargeEpisodeCtrl',
+                            'template'  : '/templates/modals/discharge_episode.html/'
+                        };
+                    }
+                };
+            }
         }
+
 
         var Flow = {
 
             enter: function(config, context){
                 var deferred = $q.defer();
-                var target = ApplicationFlow.enter();
-                result = $modal.open({
+                var target = get_flow_service().enter();
+                var result = $modal.open({
                     backdrop: 'static',
                     templateUrl: target.template,
                     controller:  target.controller,
@@ -47,8 +50,8 @@ angular.module(
 
             exit: function(episode, config, context){
                 var deferred = $q.defer();
-                var target = ApplicationFlow.exit(episode);
-                result = $modal.open({
+                var target = get_flow_service().exit(episode)
+                var result = $modal.open({
                     backdrop: 'static',
                     templateUrl: target.template,
                     controller:  target.controller,
@@ -59,9 +62,9 @@ angular.module(
                         metadata     : function(Metadata){ return Metadata.load(); },
                         tags         : function() { return config.current_tags; },
                         context      : function(){ return context; }
-      			        }
+      			    }
                 }).result;
-                deferred.resolve(result);
+
                 return deferred.promise;
             }
 

--- a/opal/static/js/opal/utils.js
+++ b/opal/static/js/opal/utils.js
@@ -2,9 +2,7 @@ var OPAL = {};
 if(undefined === version){
     var version = 'test';
 }
-if(undefined === OPAL_FLOW_SERVICE){
-    var OPAL_FLOW_SERVICE = null;
-}
+try { angular.module("opal.config") } catch(err) { /* failed to require */ angular.module('opal.config', [])}
 
 OPAL.module = function(namespace, dependencies){
     dependencies = dependencies || [];

--- a/opal/static/js/test/flow.service.test.js
+++ b/opal/static/js/test/flow.service.test.js
@@ -8,6 +8,7 @@ describe('Flow ', function(){
     var options, Flow, Referencedata;
     var metadata = {load: function(){}};
     var referencedata = {load: function(){}};
+    var mock_flow_service;
 
     beforeEach(function(){
 
@@ -15,6 +16,11 @@ describe('Flow ', function(){
         module('opal.controllers');
         spyOn(metadata, "load").and.returnValue("some metadata");
         spyOn(referencedata, "load").and.returnValue("some reference data");
+        mock_flow_service = null;
+
+        module(function($provide){
+            $provide.value('OPAL_FLOW_SERVICE', mock_flow_service);
+        });
 
         inject(function($injector){
             Flow          = $injector.get('Flow');
@@ -55,5 +61,79 @@ describe('Flow ', function(){
 
             expect(resolves.context()).toEqual({some: "context"});
         });
+    });
+});
+
+
+///
+/// For reasons beyond my comprehension, it seems impossible to
+/// re-set these mocks/injectors/providers within the same describe block, so we
+/// are starting again with a fresh context.
+///
+describe('Flow ', function(){
+    "use strict";
+    var $httpBackend, $modal, $rootScope;
+    var options, Flow, Referencedata;
+    var metadata = {load: function(){}};
+    var referencedata = {load: function(){}};
+    var mock_flow_service;
+
+    beforeEach(function(){
+
+        module('opal.services');
+        module('opal.controllers');
+        spyOn(metadata, "load").and.returnValue("some metadata");
+        spyOn(referencedata, "load").and.returnValue("some reference data");
+        mock_flow_service =  {
+            enter: jasmine.createSpy().and.returnValue(
+                {
+                    'controller': 'HospitalNumberCtrl',
+                    'template'  : '/templates/modals/hospital_number.html/'
+                }
+            ),
+            exit: jasmine.createSpy().and.returnValue(
+                {
+                    'controller': 'DischargeEpisodeCtrl',
+                    'template'  : '/templates/modals/discharge_episode.html/'
+                }
+            )
+        };
+
+        module(function($provide){
+            $provide.value('TestCustomFlowService', mock_flow_service);
+            $provide.value('OPAL_FLOW_SERVICE', 'TestCustomFlowService');
+        });
+
+        inject(function($injector){
+            Flow          = $injector.get('Flow');
+            $modal        = $injector.get('$modal');
+            $rootScope    = $injector.get('$rootScope');
+            $httpBackend  = $injector.get('$httpBackend');
+        });
+
+    });
+
+
+    describe('with custom service', function() {
+
+        describe('enter', function() {
+
+            it('should call the custom service', function() {
+                Flow.enter({hospital_number: '555-456'}, {some: "context"});
+                expect(mock_flow_service.enter).toHaveBeenCalled();
+            });
+
+        });
+
+        describe('exit', function() {
+
+            it('should call the custom service', function() {
+                Flow.exit({hospital_number: '555-456'}, {some: "context"});
+                expect(mock_flow_service.exit).toHaveBeenCalled();
+            });
+
+        });
+
+
     });
 });

--- a/opal/templates/opal.html
+++ b/opal/templates/opal.html
@@ -23,14 +23,18 @@
     {% plugin_opal_angular_tracking_exclude %}
 
     <script type="text/javascript">
+      angular.module('opal.config', []).value(
+        'OPAL_FLOW_SERVICE',
+        {% if OPAL_FLOW_SERVICE %}'{{ OPAL_FLOW_SERVICE }}'{% else %}null{% endif %}
+      );
+    </script>
+
+    <script type="text/javascript">
       var initials = "{{request.user.first_name|slice:":1"}} {{request.user.last_name}}"
       var settings = {
       LOG_OUT_DURATION: {{OPAL_LOG_OUT_DURATION}}
       }
       var version = '{{VERSION_NUMBER}}';
-      {% if OPAL_FLOW_SERVICE %}
-      var OPAL_FLOW_SERVICE = '{{ OPAL_FLOW_SERVICE }}';
-      {% endif %}
     </script>
     <!-- google analytics -->
     <script>


### PR DESCRIPTION
This allows us to set global variables in a way that we can then test, and also roll out as a way to pass settings around.
e.g. with the .value() option of the module.