### PR TITLE
Adds a link in the episode list view to their patient detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### 0.8.2 (Minor Release)
 
+### Episode/Patient links in admin
+In the admin, episodes and patients lists now have links to the patient detail pages.
+
 ### User data for the client
 
 Adds a `User` Angular service that enables applications to use user data.

--- a/opal/admin.py
+++ b/opal/admin.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin
 from django.core.exceptions import ValidationError
+from django.utils.html import format_html
 from django import forms
 
 import reversion
@@ -48,7 +49,11 @@ class MyAdmin(reversion.VersionAdmin):
 
 class EpisodeAdmin(reversion.VersionAdmin):
     list_display = [
-        'patient', 'active', 'date_of_admission', 'discharge_date'
+        'patient',
+        'active',
+        'date_of_admission',
+        'discharge_date',
+        'episode_detail_url'
     ]
     list_filter = ['active', ]
     search_fields = [
@@ -57,13 +62,27 @@ class EpisodeAdmin(reversion.VersionAdmin):
         'patient__demographics__hospital_number'
     ]
 
+    def episode_detail_url(self, obj):
+        url = "/#/patient/{0}/{1}".format(obj.patient_id, obj.id)
+        return format_html("<a href='{url}'>{url}</a>", url=url)
+
+    episode_detail_url.short_description = "Episode Detail URL"
+
 
 class PatientAdmin(reversion.VersionAdmin):
+    list_display = ('__str__', 'patient_detail_url')
+
     search_fields = [
         'demographics__first_name',
         'demographics__surname',
         'demographics__hospital_number'
     ]
+
+    def patient_detail_url(self, obj):
+        url = "/#/patient/{0}".format(obj.id)
+        return format_html("<a href='{url}'>{url}</a>", url=url)
+
+    patient_detail_url.short_description = "Patient Detail Url"
 
 
 class EpisodeSubrecordAdmin(reversion.VersionAdmin):

--- a/opal/tests/test_admin.py
+++ b/opal/tests/test_admin.py
@@ -1,13 +1,14 @@
-from opal.admin import LookupListForm
+from opal.admin import LookupListForm, PatientAdmin, EpisodeAdmin
 from opal.core.test import OpalTestCase
 from opal.tests.models import Hat
-from opal.models import Synonym
+from opal.models import Synonym, Patient, Episode
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.admin.sites import AdminSite
 
 
 class HatForm(LookupListForm):
     class Meta:
-        model=Hat
+        model = Hat
         fields = '__all__'
 
 
@@ -28,7 +29,31 @@ class LookupListFormTestCase(OpalTestCase):
             form.save()
 
     def test_valid_synonym(self):
-        hat = Hat.objects.create(name="Cowboy")
+        Hat.objects.create(name="Cowboy")
         form = HatForm()
         form.cleaned_data = dict(name="Stetson")
         self.assertEqual("Stetson", form.clean_name())
+
+
+class AdminTestCase(OpalTestCase):
+    def setUp(self):
+        self.patient, self.episode = self.new_patient_and_episode_please()
+        self.site = AdminSite()
+
+
+class EpisodeAdminTestCase(AdminTestCase):
+    def test_episode_detail_url(self):
+        admin = EpisodeAdmin(Episode, self.site)
+        self.assertEqual(
+            admin.episode_detail_url(self.episode),
+            "<a href='/#/patient/1/1'>/#/patient/1/1</a>"
+        )
+
+
+class PatientAdminTestCase(AdminTestCase):
+    def patient_detail_url(self):
+        admin = PatientAdmin(Patient, self.site)
+        self.assertEqual(
+            admin.patient_detail_url(self.patient),
+            "<a href='/#/patient/1'>/#/patient/1</a>"
+        )


### PR DESCRIPTION
Adds a link in the patient/episode list view to their patient detail page.

What would also be nice if we implemented this on the patient detail view by adding in the get_absolute_url method on the patient/episode models. I've made a ticket for this https://github.com/openhealthcare/opal/issues/1031
