### PR TITLE
changes the modal buttons for the lookup lists reference library to close

### DIFF
--- a/opal/templates/modals/lookuplist_reference.html
+++ b/opal/templates/modals/lookuplist_reference.html
@@ -10,3 +10,10 @@
   </div>
 </div>
 {% endblock %}
+
+{% block modal_save %}
+{% endblock modal_save %}
+
+{% block modal_cancel %}
+<button class="btn" ng-click="cancel()">Close</button>
+{% endblock modal_cancel %}


### PR DESCRIPTION
looks like, in other news we don't have a nice way of putting the cancel 'x' in the top right hand corner of the modal at the moment.

![screen shot 2017-03-30 at 17 52 00](https://cloud.githubusercontent.com/assets/2175455/24516180/ad6e105a-1571-11e7-8392-ee5e80adac99.png)
