### PR TITLE
Bring through symptoms patient

### DIFF
--- a/opal/core/search/extract.py
+++ b/opal/core/search/extract.py
@@ -65,15 +65,15 @@ class CsvRenderer(with_metaclass(CsvRendererMetaClass)):
         if isinstance(col_value, list):
             return "; ".join(u(str(i).encode('UTF-8')) for i in col_value)
         else:
-            return u(str(col_value).encode('UTF-8'))
+            return u(str(col_value))
 
     def get_headers(self):
         result = []
         for field in self.fields:
             if hasattr(self, field):
-                result.append(getattr(self, field).display_name)
+                result.append(u(getattr(self, field).display_name))
             else:
-                result.append(self.get_field_title(field))
+                result.append(u(self.get_field_title(field)))
         return result
 
     def get_row(self, instance, *args, **kwargs):
@@ -97,9 +97,9 @@ class CsvRenderer(with_metaclass(CsvRendererMetaClass)):
 class EpisodeCsvRenderer(CsvRenderer):
     tagging = Column(
         display_name="Tagging",
-        value=lambda self, instance: "; ".join(
+        value=lambda self, instance: u("; ".join(
             instance.get_tag_names(self.user)
-        )
+        ))
     )
 
     start = Column(
@@ -126,7 +126,7 @@ class EpisodeCsvRenderer(CsvRenderer):
 class PatientSubrecordCsvRenderer(CsvRenderer):
     episode = Column(
         display_name="Episode",
-        value=lambda self, instance, episode_id: str(episode_id)
+        value=lambda self, instance, episode_id: u(str(episode_id))
     )
 
     def get_field_names_to_render(self):
@@ -140,7 +140,7 @@ class PatientSubrecordCsvRenderer(CsvRenderer):
 class EpisodeSubrecordCsvRenderer(CsvRenderer):
     patient = Column(
         display_name="Patient",
-        value=lambda self, instance: str(instance.episode.patient_id)
+        value=lambda self, instance: u(str(instance.episode.patient_id))
     )
 
     def get_field_names_to_render(self):

--- a/opal/core/search/extract.py
+++ b/opal/core/search/extract.py
@@ -16,7 +16,8 @@ from opal.core.subrecords import (
     episode_subrecords, patient_subrecords, subrecords
 )
 
-from six import u, with_metaclass
+from six import with_metaclass
+from django.utils.translation import ugettext as _
 
 Column = namedtuple("Column", ["display_name", "value"])
 
@@ -63,17 +64,17 @@ class CsvRenderer(with_metaclass(CsvRendererMetaClass)):
     def get_field_value(self, field_name, data):
         col_value = data[field_name]
         if isinstance(col_value, list):
-            return "; ".join(u(str(i).encode('UTF-8')) for i in col_value)
+            return "; ".join(_(str(i).encode('UTF-8')) for i in col_value)
         else:
-            return u(str(col_value))
+            return _(str(col_value))
 
     def get_headers(self):
         result = []
         for field in self.fields:
             if hasattr(self, field):
-                result.append(u(getattr(self, field).display_name))
+                result.append(_(getattr(self, field).display_name))
             else:
-                result.append(u(self.get_field_title(field)))
+                result.append(_(self.get_field_title(field)))
         return result
 
     def get_row(self, instance, *args, **kwargs):
@@ -97,7 +98,7 @@ class CsvRenderer(with_metaclass(CsvRendererMetaClass)):
 class EpisodeCsvRenderer(CsvRenderer):
     tagging = Column(
         display_name="Tagging",
-        value=lambda self, instance: u("; ".join(
+        value=lambda self, instance: _("; ".join(
             instance.get_tag_names(self.user)
         ))
     )
@@ -126,7 +127,7 @@ class EpisodeCsvRenderer(CsvRenderer):
 class PatientSubrecordCsvRenderer(CsvRenderer):
     episode = Column(
         display_name="Episode",
-        value=lambda self, instance, episode_id: u(str(episode_id))
+        value=lambda self, instance, episode_id: _(str(episode_id))
     )
 
     def get_field_names_to_render(self):
@@ -140,7 +141,7 @@ class PatientSubrecordCsvRenderer(CsvRenderer):
 class EpisodeSubrecordCsvRenderer(CsvRenderer):
     patient = Column(
         display_name="Patient",
-        value=lambda self, instance: u(str(instance.episode.patient_id))
+        value=lambda self, instance: _(str(instance.episode.patient_id))
     )
 
     def get_field_names_to_render(self):

--- a/opal/tests/test_search_extract.py
+++ b/opal/tests/test_search_extract.py
@@ -337,3 +337,27 @@ class TestEpisodeSubrecordCsvRenderer(OpalTestCase):
     def test_get_rows(self):
         rendered = self.renderer.get_row(self.colour)
         self.assertEqual(["1", "1", "blue"], rendered)
+
+class TestInheritedRenderer(OpalTestCase):
+    def setUp(self):
+        class ColourCsvRenderer(extract.EpisodeSubrecordCsvRenderer):
+            name = extract.Column(
+                display_name="Some Colour",
+                value=lambda self, instance: "Some value"
+            )
+
+        _, self.episode = self.new_patient_and_episode_please()
+        self.colour = Colour.objects.create(
+            name="blue", episode=self.episode
+        )
+        self.renderer = ColourCsvRenderer(
+            Colour, self.user, fields=["patient", "episode_id", "name"]
+        )
+
+    def test_get_header(self):
+        expected = ["Patient", "Episode", "Some Colour"]
+        self.assertEqual(expected, self.renderer.get_headers())
+
+    def test_get_rows(self):
+        rendered = self.renderer.get_row(self.colour)
+        self.assertEqual(["1", "1", "Some value"], rendered)

--- a/opal/tests/test_search_extract.py
+++ b/opal/tests/test_search_extract.py
@@ -94,18 +94,19 @@ class SubrecordCSVTestCase(PatientEpisodeTestCase):
         file_name = "fake file name"
 
         self.mocked_extract(
-            extract.subrecord_csv,
-            [[], Colour, file_name]
+            extract.episode_subrecord_csv,
+            [[], self.user, Colour, file_name]
         )
         headers = csv.writer().writerow.call_args_list[0][0][0]
         self.assertEqual(csv.writer().writerow.call_count, 1)
         expected_headers = [
-            'created',
-            'updated',
-            'created_by_id',
-            'updated_by_id',
-            'episode_id',
-            'name'
+            'Patient',
+            'Created',
+            'Updated',
+            'Created By',
+            'Updated By',
+            'Episode',
+            'Name'
         ]
         self.assertEqual(headers, expected_headers)
 
@@ -116,22 +117,23 @@ class SubrecordCSVTestCase(PatientEpisodeTestCase):
         colour = Colour.objects.create(episode=self.episode, name='blue')
 
         self.mocked_extract(
-            extract.subrecord_csv,
-            [[self.episode], Colour, file_name]
+            extract.episode_subrecord_csv,
+            [[self.episode], self.user, Colour, file_name]
         )
 
         headers = csv.writer().writerow.call_args_list[0][0][0]
         row = csv.writer().writerow.call_args_list[1][0][0]
         expected_headers = [
-            'created',
-            'updated',
-            'created_by_id',
-            'updated_by_id',
-            'episode_id',
-            'name'
+            'Patient',
+            'Created',
+            'Updated',
+            'Created By',
+            'Updated By',
+            'Episode',
+            'Name'
         ]
         expected_row = [
-            u'None', u'None', u'None', u'None', str(self.episode.id), u'blue'
+            str(self.patient.id), u'None', u'None', u'None', u'None', str(self.episode.id), u'blue'
         ]
         self.assertEqual(headers, expected_headers)
         self.assertEqual(row, expected_row)
@@ -145,30 +147,33 @@ class PatientSubrecordCSVTestCase(PatientEpisodeTestCase):
         file_name = "fake file name"
         self.mocked_extract(
             extract.patient_subrecord_csv,
-            [[self.episode], Demographics, file_name]
+            [[self.episode], self.user, Demographics, file_name]
         )
         headers = csv.writer().writerow.call_args_list[0][0][0]
         row = csv.writer().writerow.call_args_list[1][0][0]
         expected_headers = [
-            'episode_id',
-            'created',
-            'updated',
-            'created_by_id',
-            'updated_by_id',
-            'hospital_number',
-            'nhs_number',
-            'date_of_birth',
-            'death_indicator',
-            'sex',
-            'birth_place',
+            'Patient',
+            'Episode',
+            'Created',
+            'Updated',
+            'Created By',
+            'Updated By',
+            'Hospital Number',
+            'Nhs Number',
+            'Date Of Birth',
+            'Death Indicator',
+            'Sex',
+            'Birth Place',
         ]
-        self.assertEqual(headers[0], 'episode_id')
         for h in expected_headers:
-            self.assertTrue(h in headers)
+            self.assertTrue(
+                h in headers,
+                "{0} not in {1}".format(h, headers)
+            )
 
         expected_row = [
-            1, u'None', u'None', u'None', u'None', u'12345678',
-            u'None', u'1976-01-01', u'False', u'', u''
+                '1', u'None', u'None', u'None', u'None', u'1',
+                u'12345678', u'None', u'1976-01-01', u'False', u'', u''
         ]
         self.assertEqual(row, expected_row)
 
@@ -184,7 +189,7 @@ class ZipArchiveTestCase(PatientEpisodeTestCase):
         extract.zip_archive(models.Episode.objects.all(), 'this', self.user)
         self.assertEqual(4, zipfile.ZipFile.return_value.__enter__.return_value.write.call_count)
 
-    @patch('opal.core.search.extract.subrecord_csv')
+    @patch('opal.core.search.extract.episode_subrecord_csv')
     @patch('opal.core.search.extract.zipfile')
     def test_exclude_episode_subrecords(self, zipfile, subrecords):
         extract.zip_archive(models.Episode.objects.all(), 'this', self.user)

--- a/opal/tests/test_search_extract.py
+++ b/opal/tests/test_search_extract.py
@@ -4,6 +4,7 @@ Unittests for opal.core.search.extract
 import datetime
 import json
 from mock import mock_open, Mock, patch
+from six import u
 
 from django.core.urlresolvers import reverse
 from django.test import override_settings
@@ -314,11 +315,11 @@ class TestPatientSubrecordCsvRenderer(OpalTestCase):
         )
 
     def test_get_header(self):
-        self.assertEqual(["Patient", "Episode", "Name"], self.renderer.get_headers())
+        self.assertEqual([u("Patient"), u("Episode"), u("Name")], self.renderer.get_headers())
 
     def test_get_rows(self):
         rendered = self.renderer.get_row(self.patient_colour, self.episode.id)
-        self.assertEqual(["1", "1", "blue"], rendered)
+        self.assertEqual([u("1"), u("1"), u("blue")], rendered)
 
 
 class TestEpisodeSubrecordCsvRenderer(OpalTestCase):
@@ -332,11 +333,11 @@ class TestEpisodeSubrecordCsvRenderer(OpalTestCase):
         )
 
     def test_get_header(self):
-        self.assertEqual(["Patient", "Episode", "Name"], self.renderer.get_headers())
+        self.assertEqual([u("Patient"), u("Episode"), u("Name")], self.renderer.get_headers())
 
     def test_get_rows(self):
         rendered = self.renderer.get_row(self.colour)
-        self.assertEqual(["1", "1", "blue"], rendered)
+        self.assertEqual([u("1"), u("1"), u("blue")], rendered)
 
 class TestInheritedRenderer(OpalTestCase):
     def setUp(self):
@@ -355,9 +356,9 @@ class TestInheritedRenderer(OpalTestCase):
         )
 
     def test_get_header(self):
-        expected = ["Patient", "Episode", "Some Colour"]
+        expected = [u("Patient"), u("Episode"), u("Some Colour")]
         self.assertEqual(expected, self.renderer.get_headers())
 
     def test_get_rows(self):
         rendered = self.renderer.get_row(self.colour)
-        self.assertEqual(["1", "1", "Some value"], rendered)
+        self.assertEqual([u("1"), u("1"), u("Some value")], rendered)


### PR DESCRIPTION
This is a little bit much.. Essentially it was on the thinking that we want some sort of serialisation into different formats.

It gives us display names in the headers and we have the patient id in every row obviously. It also lets us pass in fields for the next stage.

- Display name as col headers
- Symptoms M2m in extract
- Use to_dict to re-use getters
- Pass in fields to render as a csv
- Adds patient_id to every row