### PR TITLE
fixes the patient subrecord extract

### DIFF
--- a/opal/tests/test_search_extract.py
+++ b/opal/tests/test_search_extract.py
@@ -365,13 +365,11 @@ class TestPatientSubrecordCsvRenderer(PatientEpisodeTestCase):
         self.assertEqual([["1", "1", "blue"]], rendered)
 
     def test_get_rows_same_patient(self, field_names_to_extract):
+        self.patient.create_episode()
         field_names_to_extract.return_value = [
             "patient_id", "name", "consistency_token", "id"
         ]
 
-        PatientColour.objects.create(
-            name="green", patient=self.patient
-        )
         renderer = extract.PatientSubrecordCsvRenderer(
             PatientColour,
             models.Episode.objects.all(),
@@ -382,7 +380,7 @@ class TestPatientSubrecordCsvRenderer(PatientEpisodeTestCase):
         )
         self.assertEqual([
             ["1", "1", "blue"],
-            ["1", "1", "green"]
+            ["2", "1", "blue"]
         ], rendered)
 
 

--- a/opal/tests/test_search_extract.py
+++ b/opal/tests/test_search_extract.py
@@ -364,6 +364,27 @@ class TestPatientSubrecordCsvRenderer(PatientEpisodeTestCase):
         )
         self.assertEqual([["1", "1", "blue"]], rendered)
 
+    def test_get_rows_same_patient(self, field_names_to_extract):
+        field_names_to_extract.return_value = [
+            "patient_id", "name", "consistency_token", "id"
+        ]
+
+        PatientColour.objects.create(
+            name="green", patient=self.patient
+        )
+        renderer = extract.PatientSubrecordCsvRenderer(
+            PatientColour,
+            models.Episode.objects.all(),
+            self.user
+        )
+        rendered = list(
+            renderer.get_rows()
+        )
+        self.assertEqual([
+            ["1", "1", "blue"],
+            ["1", "1", "green"]
+        ], rendered)
+
 
 @patch.object(Colour, "_get_fieldnames_to_extract")
 class TestEpisodeSubrecordCsvRenderer(PatientEpisodeTestCase):


### PR DESCRIPTION
fixes the patient extract so that we have 1 per episode.

Note is *shouldn't*(TM) be that inefficient as the instance will be fully loaded. There may be a cost for ForeignKeyOrFreeText