### PR TITLE
subrecord-display-hypothesis HYPOTHESIS, NOT FOR MERGING

### DIFF
--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -54,9 +54,7 @@ class ModelColumn(Column):
         self.single = model._is_singleton
         self.icon = getattr(model, '_icon', '')
         self.list_limit = getattr(model, '_list_limit', None)
-        self.template_path = model.get_display_template(
-            patient_list=self.patient_list()
-        )
+        self.template_path = ""
         self.detail_template_path = model.get_detail_template(
             patient_list=self.patient_list()
         )
@@ -64,6 +62,7 @@ class ModelColumn(Column):
     def to_dict(self, **kwargs):
         dicted = super(ModelColumn, self).to_dict(**kwargs)
         dicted['model_column'] = True
+        dicted['model'] = self.model
         return dicted
 
 
@@ -127,8 +126,8 @@ class PatientList(discoverable.DiscoverableFeature,
         return [self.template_name]
 
     def to_dict(self, user):
-        from opal.models import Episode
-        return Episode.objects.serialised(user, self.get_queryset(user=user))
+        # only bringing in active seems a sensible default at this time
+        return self.get_queryset(user=user).serialised_active(user)
 
 
 class TaggedPatientList(PatientList, utils.AbstractBase):
@@ -191,11 +190,6 @@ class TaggedPatientList(PatientList, utils.AbstractBase):
         if hasattr(self, 'subtag'):
             possible.append("{0}.{1}".format(self.tag, self.subtag))
         return possible
-
-    def to_dict(self, user):
-        # As opposed to general lists, we only ever want active episodes
-        # for tagged lists
-        return self.get_queryset(user=user).serialised_active(user)
 
 
 """

--- a/opal/models.py
+++ b/opal/models.py
@@ -940,13 +940,22 @@ class Subrecord(UpdatesFromDictMixin, ToDictMixin, TrackedModel, models.Model):
         return templates
 
     @classmethod
-    def get_display_template(cls, episode_type=None, patient_list=None):
+    def get_display_template(cls, list_prefixes=None):
         """
         Return the active display template for our record
         """
-        templates = cls._build_template_selection(
-            episode_type=episode_type, patient_list=patient_list,
-            suffix='.html', prefix='records')
+
+        name = cls.get_api_name()
+        list_prefixes = list_prefixes or []
+
+        templates = []
+
+        for list_prefix in list_prefixes:
+            templates.append(
+                'records/{0}/{1}.html'.format(list_prefix, name)
+            )
+
+        templates.append('records/{0}.html'.format(name))
         return find_template(templates)
 
     @classmethod

--- a/opal/templates/patient_lists/spreadsheet_list.html
+++ b/opal/templates/patient_lists/spreadsheet_list.html
@@ -1,5 +1,6 @@
 {% extends 'layouts/left_panel.html' %}
 {% load patient_lists %}
+{% load subrecord_display %}
 {% block heading %}
 <div class="row screen-only">
   <div class="col-md-12">
@@ -81,11 +82,11 @@
   </div>
   <div class="panel-body">
     <p>
-	  <input class="form-control" ng-model="query.hospital_number"
+	  <input class="form-control" ng-model="query.hospital_number" ng-change="filterEpisodes()"
              ui-event="{focus: 'focusOnQuery()', blur: 'blurOnQuery()'}"
              type="text" class="input-small" placeholder="Hospital #">
 	  <input class="form-control" ng-model="query.name" ui-event="{focus: 'focusOnQuery()', blur: 'blurOnQuery()'}"
-             type="text" class="input-small" placeholder="Name">
+              ng-change="filterEpisodes()" type="text" class="input-small" placeholder="Name">
     </p>
   </div>
 </div>
@@ -109,12 +110,12 @@
           <div class="row">
             <div class="col-sm-6">
               <div ng-repeat="item in row.demographics">
-                {% include models.Demographics.get_display_template %}
+                {% subrecord_display models.Demographics patient_list.get_template_prefixes %}
               </div>
             </div>
             <div class="col-sm-6">
               <div ng-repeat="item in row.diagnosis">
-                {% include models.Diagnosis.get_display_template %}
+                {% subrecord_display models.Diagnosis patient_list.get_template_prefixes %}
               </div>
             </div>
           </div>
@@ -151,7 +152,7 @@
   		    <li ng-repeat="item in row.{{column.name}} {% if column.list_limit %} |limitTo:{{ column.list_limit }}{% endif %} track by $index"
   			    ng-dblclick="editNamedItem(row, '{{column.name}}', $index);$event.stopPropagation()"
   			    >
-  			  {% include column.template_path %}
+  			  {% subrecord_display column.model patient_list.get_template_prefixes %}
   		    </li>
 
   		    {% if not column.single %}

--- a/opal/templatetags/subrecord_display.py
+++ b/opal/templatetags/subrecord_display.py
@@ -1,0 +1,46 @@
+from django import template
+from django.template.loader import get_template
+register = template.Library()
+
+
+class SubrecordDisplayNode(template.Node):
+    def __init__(self, subrecord, prefixes=None):
+        self.subrecord = subrecord
+        self.prefixes = prefixes
+
+    def render(self, context):
+        subrecord = self.subrecord.resolve(context)
+        if self.prefixes:
+            prefixes = self.prefixes.resolve(context)
+            template_name = subrecord.get_display_template(
+                list_prefixes=prefixes
+            )
+        else:
+            template_name = subrecord.get_display_template()
+
+        t = get_template(template_name)
+        return t.render(context)
+
+
+def subrecord_display(parser, token):
+    """
+        a template tag that takes in a bunch of path prefixes
+        and looks for a subrecord display template with those
+        prefixes or its own.
+
+        e.g.
+        {% subrecord_display models.Demographics '["someTag"]' %}
+    """
+
+    tokens = token.split_contents()
+    prefixes = tokens[2]
+
+    if prefixes:
+        prefixes = parser.compile_filter(prefixes)
+
+    return SubrecordDisplayNode(
+        parser.compile_filter(tokens[1]),
+        prefixes
+    )
+
+register.tag('subrecord_display', subrecord_display)


### PR DESCRIPTION
What do you think about this?

Essentially we want to decouple patient lists from get_display_template, or at least make it very flexible and easy for both patient detail and patient lists to use the same template.

In an ideal world, we would probably do something like

{% include models.Demographics.get_display_template(patient_list.get_prefixes) %}

and essentially this allows us to do this.

The in the patient detail views we can do the version of..

{% include models.Demographics.get_display_template(["walkin") %}

needs unit tests, its an experiment, thoughts?