### PR TITLE
because we import application in __init__ we need make sure that we d…

### DIFF
--- a/opal/core/application.py
+++ b/opal/core/application.py
@@ -6,8 +6,6 @@ import itertools
 import os
 
 from django.core.urlresolvers import reverse
-from django.contrib.auth.views import logout as logout_view
-
 from opal.core import plugins, menus
 
 
@@ -133,6 +131,8 @@ class OpalApplication(object):
         """
         Default implementation of get_menu_items()
         """
+        # we import here as settings must be set before this is imported
+        from django.contrib.auth.views import logout as logout_view
         logout = menus.MenuItem(
             href=reverse(logout_view), icon="fa-sign-out", index=1000
         )


### PR DESCRIPTION
…on't import dependencies that depend on settings having been set