### PR TITLE
we include compressor because otherwise any template get unit tests w…

### DIFF
--- a/opal/scaffolding/plugin_scaffold/requirements.txt.jinja2
+++ b/opal/scaffolding/plugin_scaffold/requirements.txt.jinja2
@@ -1,3 +1,4 @@
 python-dateutil==2.4.2
 mock==1.0.1
+django-compressor==1.5
 opal=={{ version }}

--- a/opal/scaffolding/plugin_scaffold/runtests.py.jinja2
+++ b/opal/scaffolding/plugin_scaffold/runtests.py.jinja2
@@ -30,6 +30,7 @@ settings.configure(DEBUG=True,
                                    'django.contrib.sessions',
                                    'django.contrib.staticfiles',
                                    'django.contrib.admin',
+                                   'compressor',
                                    'opal',
                                    '{{ name }}',))
 


### PR DESCRIPTION
…ill fail because the template bases rely on using the compressor template tags