### PR TITLE
add a karma config to the plugin creation

### DIFF
--- a/opal/scaffolding/plugin_scaffold/config/karma.conf.js.jinja2
+++ b/opal/scaffolding/plugin_scaffold/config/karma.conf.js.jinja2
@@ -1,0 +1,22 @@
+module.exports = function(config){
+  var opalPath;
+  if(process.env.TRAVIS){
+    python_version = process.env.TRAVIS_PYTHON_VERSION;
+    opalPath = '/home/travis/virtualenv/python' + python_version + '/src/opal';
+  }
+  else{
+    opalPath = '../../opal';
+  }
+  var karmaDefaults = require(opalPath + '/config/karma_defaults.js');
+  var baseDir = __dirname + '/..';
+  var coverageFiles = [
+    __dirname+'/../{{ name }}/static/js/{{ name }}/**/*.js',
+  ];
+    var includedFiles = [
+      __dirname+'/../{{ name }}/static/js/{{ name }}/**/*.js',
+      __dirname+'/../{{ name }}/static/js/test/*.js',
+  ];
+
+  var defaultConfig = karmaDefaults(includedFiles, baseDir, coverageFiles);
+  config.set(defaultConfig);
+};

--- a/opal/scaffolding/plugin_scaffold/config/karma.conf.js.jinja2
+++ b/opal/scaffolding/plugin_scaffold/config/karma.conf.js.jinja2
@@ -5,7 +5,7 @@ module.exports = function(config){
     opalPath = '/home/travis/virtualenv/python' + python_version + '/src/opal';
   }
   else{
-    // this should point to the location of opal on your machine, it may be in the virtualenv
+    // this should point to the location of Opal on your machine, it may be in the virtualenv
     opalPath = '../../opal';
   }
   var karmaDefaults = require(opalPath + '/config/karma_defaults.js');

--- a/opal/scaffolding/plugin_scaffold/config/karma.conf.js.jinja2
+++ b/opal/scaffolding/plugin_scaffold/config/karma.conf.js.jinja2
@@ -5,6 +5,7 @@ module.exports = function(config){
     opalPath = '/home/travis/virtualenv/python' + python_version + '/src/opal';
   }
   else{
+    // this should point to the location of opal on your machine, it may be in the virtualenv
     opalPath = '../../opal';
   }
   var karmaDefaults = require(opalPath + '/config/karma_defaults.js');


### PR DESCRIPTION
I always want this, but it does assume you're using the generic opal folder structure, ie that opal is ../../opal

I've put a comment, I think its good to have a karma config that will help you out of the box, my worry is if you don't have opal in the right place it may lead you astray. Thoughts?