### PR TITLE
Generate requirements.txt for applications using a template. #1110.

### DIFF
--- a/opal/core/scaffold.py
+++ b/opal/core/scaffold.py
@@ -149,7 +149,8 @@ def start_project(name, USERLAND_HERE):
     gitignore.mv(project_dir/'.gitignore')
 
     # Interpolate the project data
-    interpolate_dir(project_dir, name=name, secret_key=get_random_secret_key())
+    interpolate_dir(project_dir, name=name, secret_key=get_random_secret_key(),
+                    version=opal.__version__)
 
     app_dir = project_dir/name
 

--- a/opal/scaffolding/scaffold/requirements.txt.jinja2
+++ b/opal/scaffolding/scaffold/requirements.txt.jinja2
@@ -18,4 +18,4 @@ supervisor==3.0
 python-dateutil==2.4.2
 django-celery==3.1.17
 celery==3.1.19
-opal==0.9.0
+opal=={{version}}


### PR DESCRIPTION
Hello,

Now both project & plugin scaffolds generate their requirements.txt via jinja2 template.  Both scaffolds are covered by new unit tests, both of which pass along with all other existing tests.

Let me know if I've missed anything!

Cheers,
Peter.


```
opalpeter@t440:~/github/opal$ opal test -c
Running Python Unit Tests
Creating test database for alias 'default'...
.....................................................................................................................................................................................................................................................................................................................WARNING:py.warnings:/home/peter/.local/share/virtualenvs/opal/local/lib/python2.7/site-packages/Django-1.8.13-py2.7.egg/django/db/models/fields/__init__.py:1474: RuntimeWarning: DateTimeField Demographics.created received a naive datetime (2017-06-01 20:23:50.376510) while time zone support is active.
  RuntimeWarning)

.............................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 738 tests in 14.886s

OK
Destroying test database for alias 'default'...
Running Javascript Unit Tests
01 06 2017 20:24:02.249:WARN [watcher]: All files matched by "/home/peter/github/opal/opal/static/js/opal/services/flow.js" were excluded or matched by prior matchers.
01 06 2017 20:24:02.638:INFO [karma]: Karma v1.7.0 server started at http://0.0.0.0:9876/
01 06 2017 20:24:02.639:INFO [launcher]: Launching browser PhantomJS with unlimited concurrency
01 06 2017 20:24:02.646:INFO [launcher]: Starting browser PhantomJS
01 06 2017 20:24:02.856:INFO [PhantomJS 2.1.1 (Linux 0.0.0)]: Connected on socket 6lBUDfeuw2cnUVyMAAAA with id 47126359
PhantomJS 2.1.1 (Linux 0.0.0): Executed 477 of 477 SUCCESS (3.09 secs / 2.893 secs)
opalpeter@t440:~/github/opal$
```