### PR TITLE
Add eq/ne operators for the MenuItem class.

### DIFF
--- a/opal/core/menus.py
+++ b/opal/core/menus.py
@@ -16,6 +16,23 @@ class MenuItem(object):
     def __repr__(self):
         return u"<Opal MenuItem href: '{0}'>".format(self.href)
 
+    def __eq__(self, other):
+        if not isinstance(other, MenuItem):
+            return NotImplemented
+
+        return (self.template_name == other.template_name and
+                self.activepattern == other.activepattern and
+                self.href == other.href and
+                self.icon == other.icon and
+                self.display == other.display and
+                self.index == other.index)
+
+    def __ne__(self, other):
+        if not isinstance(other, MenuItem):
+            return NotImplemented
+
+        return not self == other
+
 
 class Menu(object):
 

--- a/opal/tests/test_core_menus.py
+++ b/opal/tests/test_core_menus.py
@@ -1,6 +1,7 @@
 """
 Unittests for opal.core.menus
 """
+import operator
 import warnings
 
 from mock import patch, MagicMock
@@ -40,6 +41,48 @@ class MenuItemTestCase(OpalTestCase):
     def test_repr(self):
         item = menus.MenuItem(href="/wat/")
         self.assertEqual("<Opal MenuItem href: '/wat/'>", item.__repr__())
+
+    def test_equality(self):
+        item1 = menus.MenuItem(
+            template_name='menu.html',
+            activepattern='/item1',
+            href='/item1/',
+            icon='fa-item1',
+            display="Item1",
+            index=0
+        )
+
+        item1dup = menus.MenuItem(
+            template_name='menu.html',
+            activepattern='/item1',
+            href='/item1/',
+            icon='fa-item1',
+            display="Item1",
+            index=0
+        )
+
+        item2 = menus.MenuItem(
+            template_name='menu.html',
+            activepattern='/item2',
+            href='/item2/',
+            icon='fa-item2',
+            display="Item2",
+            index=0
+        )
+
+        self.assertTrue(item1 == item1)
+        self.assertTrue(operator.eq(item1, item1))
+        self.assertTrue(item1 == item1dup)
+        self.assertTrue(operator.eq(item1, item1dup))
+        self.assertTrue(item1dup == item1)
+        self.assertTrue(operator.eq(item1dup, item1))
+        self.assertTrue(item1 != item2)
+        self.assertTrue(operator.ne(item1, item2))
+        self.assertFalse(operator.ne(item1, item1dup))
+        self.assertFalse(item1 == 1)
+        self.assertFalse(1 == item2)
+        self.assertTrue(1 != item2)
+        self.assertTrue(item2 != 1)
 
 
 @patch('opal.core.plugins.OpalPlugin.list')


### PR DESCRIPTION
This provides object equality for the menuitem class rather than "visual" equality  Unit test coverage remains at 100%.

Resolves #1148 