### PR TITLE
removing unused block

### DIFF
--- a/opal/static/js/opal/services/fields_translater.js
+++ b/opal/static/js/opal/services/fields_translater.js
@@ -39,12 +39,6 @@ angular.module('opal.services').service('FieldTranslater', function($rootScope){
           }
           return moment(fieldValue, DATETIME_FORMAT);
       }
-      //
-      // TODO: Handle this conversion better
-      //
-      if (fieldMapping.type == 'integer' && fieldMapping.name == 'time') {
-          return parseInt('' + fieldValue.hour() + fieldValue.minute());
-      }
 
       return fieldValue;
   };

--- a/opal/static/js/test/episode.service.test.js
+++ b/opal/static/js/test/episode.service.test.js
@@ -279,6 +279,36 @@ describe('Episode', function() {
                 expect(mock_new).toHaveBeenCalled();
             });
 
+            it('Should call the error callback on error', function () {
+                var mock_new = jasmine.createSpy('Mock for new patient')
+                var search_url = '/search/patient/';
+                search_url += '?hospital_number=notarealnumber'
+                $httpBackend.expectGET(search_url).respond([1, 2, 3]);
+                var err = jasmine.createSpy();
+
+                Episode.findByHospitalNumber('notarealnumber', {
+                  newPatient: mock_new,
+                  error: err
+                })
+
+                $httpBackend.flush();
+                $scope.$digest();
+                expect(err).toHaveBeenCalled();
+            });
+
+            it('should handle the case where no number is passed in', function(){
+              var mock_new = jasmine.createSpy('Mock for new patient');
+
+              Episode.findByHospitalNumber(null, {
+                newPatient: mock_new
+              });
+
+              $scope.$digest();
+
+              expect(mock_new).toHaveBeenCalled();
+            });
+
+
             it('Should cast the new patient and call the newForPatient callback', function () {
                 var mock_new = jasmine.createSpy('Mock for new patient')
                 var search_url = '/search/patient/';


### PR DESCRIPTION
I don't think this is ever used, it seems to come from 3 years ago from 

https://github.com/openhealthcare/opal/blame/v0.4.3/opal/static/js/opal/services/item.js

At that time I don't think we ever had integer fields, or if we did they were from observations and those aren't relative here.

I've tested with observations and time fields just to make sure and they work fine.