### PR TITLE
Fixup teams search rule descriptoin

### DIFF
--- a/opal/core/search/search_rule.py
+++ b/opal/core/search/search_rule.py
@@ -114,7 +114,7 @@ class EpisodeTeam(SearchRuleField):
     ANY_OF = "Any Of"
 
     display_name = "Team"
-    description = "The team that looked after that episode of care"
+    description = "The team(s) related to an episode of care"
     field_type = "many_to_many_multi_select"
 
     @property

--- a/opal/tests/test_core_schemas.py
+++ b/opal/tests/test_core_schemas.py
@@ -94,7 +94,7 @@ episode_serialised = {
             'description': "Episode End"
         },
         {
-            'description': 'The team that looked after that episode of care',
+            'description': 'The team(s) related to an episode of care',
             'enum': [],
             'lookup_list': None,
             'name': 'team',


### PR DESCRIPTION
e.g. it's not the episode of care that you look after...

TBH I'm not entirely comfortable conflating `opal.models.Tagging` with "Team" within Opal... 