### PR TITLE
352 our progressbar is a liar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.9.1 (Minor Release)
+
+### Misc Changes
+
+Fixes some instances of progressbars not being set if unexpected error states occur.
+
 ### 0.9.0 (Major Release)
 
 #### Good bye date_of_episode, discharge_date, date_of_admission

--- a/opal/core/search/static/js/search/controllers/save_filter.js
+++ b/opal/core/search/static/js/search/controllers/save_filter.js
@@ -1,20 +1,25 @@
 angular.module('opal.controllers')
     .controller('SaveFilterCtrl', function($scope, $modalInstance, ngProgressLite, Filter, params) {
-    $scope.model = params;
+        $scope.model = params;
 
-	$scope.save = function(result) {
-    var filter = new Filter($scope.model);
-    ngProgressLite.set(0);
-    ngProgressLite.start();
-		filter.save($scope.model).then(function(result) {
-      ngProgressLite.done();
-			$modalInstance.close(result);
-		});
-	};
+	    $scope.save = function(result) {
+            var filter = new Filter($scope.model);
+            ngProgressLite.set(0);
+            ngProgressLite.start();
+		    filter.save($scope.model).then(
+                function(result) {
+                    ngProgressLite.done();
+			        $modalInstance.close(result);
+		        },
+                function() {
+                    ngProgressLite.done();
+                }
+            );
+	    };
 
 
-	$scope.cancel = function() {
-		$modalInstance.close('cancel');
-	};
+	    $scope.cancel = function() {
+		    $modalInstance.close('cancel');
+	    };
 
-})
+    })

--- a/opal/core/search/static/js/search/controllers/search.js
+++ b/opal/core/search/static/js/search/controllers/search.js
@@ -53,11 +53,16 @@ angular.module('opal.controllers').controller(
         ngProgressLite.set(0);
         ngProgressLite.start();
         var queryParams = $location.search();
-        queryBackend(queryParams).then(function(response){
-            ngProgressLite.done();
-            $scope.searched = true;
-            $scope.paginator = new Paginator($scope.search, response.data);
-        });
+        queryBackend(queryParams).then(
+            function(response){
+                ngProgressLite.done();
+                $scope.searched = true;
+                $scope.paginator = new Paginator($scope.search, response.data);
+            },
+            function(){
+                ngProgressLite.done();
+            }
+        );
     }
   };
 

--- a/opal/core/search/static/js/search/services/filter.js
+++ b/opal/core/search/static/js/search/services/filter.js
@@ -33,6 +33,7 @@ recently changed it - refresh the page and try again');
 		            } else {
 			            $window.alert('Item could not be saved');
 		            };
+                    deferred.reject()
 		        }
             );
             return deferred.promise;

--- a/opal/core/search/static/js/test/save_filter.controller.test.js
+++ b/opal/core/search/static/js/test/save_filter.controller.test.js
@@ -1,31 +1,31 @@
 describe('SaveFilterCtrl', function() {
     "use strict";
 
-    var $scope, $httpBackend, $controller, $rootScope, $modal;
-    var modalInstance;
-    var mock_ng_progress;
+    var $scope, $httpBackend, $controller, $rootScope, $modal, $window;
+    var modalInstance, ngProgressLite;
 
 
     beforeEach(function(){
         module('opal.controllers');
 
         inject(function($injector){
-            $httpBackend = $injector.get('$httpBackend');
-            $rootScope   = $injector.get('$rootScope');
-            $scope       = $rootScope.$new();
-            $controller  = $injector.get('$controller');
-            $modal       = $injector.get('$modal');
+            $httpBackend     = $injector.get('$httpBackend');
+            $rootScope       = $injector.get('$rootScope');
+            $scope           = $rootScope.$new();
+            $controller      = $injector.get('$controller');
+            $modal           = $injector.get('$modal');
+            ngProgressLite   = $injector.get('ngProgressLite');
+            $window          = $injector.get('$window');
+
         });
 
         modalInstance = $modal.open({template: 'notatemplate'});
-        mock_ng_progress = {
-
-        }
 
         $controller('SaveFilterCtrl', {
             $scope: $scope,
             $modalInstance: modalInstance,
-            params: {}
+            params: {},
+            ngProgressLite: ngProgressLite
         })
     });
 
@@ -37,6 +37,16 @@ describe('SaveFilterCtrl', function() {
             $scope.save();
             $rootScope.$apply();
             $httpBackend.flush();
+        });
+
+        it('should kill the progressbar if we error', function() {
+            $httpBackend.expectPOST('/search/filters/').respond(500)
+            spyOn(ngProgressLite, 'done');
+            spyOn($window, 'alert');
+            $scope.save();
+            $rootScope.$apply();
+            $httpBackend.flush();
+            expect(ngProgressLite.done).toHaveBeenCalledWith();
         });
 
     });

--- a/opal/core/search/static/js/test/search.controller.test.js
+++ b/opal/core/search/static/js/test/search.controller.test.js
@@ -2,6 +2,7 @@ describe('SearchCtrl', function (){
     "use strict";
 
     var $scope, $httpBackend, $window, $rootScope, $controller;
+    var ngProgressLite
     var location;
     var Flow;
     var profile, schema, options, locationDetails, controller;
@@ -19,20 +20,20 @@ describe('SearchCtrl', function (){
 
         inject(function($injector){
 
-            $rootScope     = $injector.get('$rootScope');
-            $scope         = $rootScope.$new();
-            $controller    = $injector.get('$controller');
-            Flow           = $injector.get('Flow');
-            PatientSummary = $injector.get('PatientSummary');
-            $httpBackend   = $injector.get('$httpBackend');
-            location       = $injector.get('$location');
-            $window        = $injector.get('$window');
-            $analytics     = $injector.get('$analytics');
+            $rootScope       = $injector.get('$rootScope');
+            $scope           = $rootScope.$new();
+            $controller      = $injector.get('$controller');
+            Flow             = $injector.get('Flow');
+            PatientSummary   = $injector.get('PatientSummary');
+            $httpBackend     = $injector.get('$httpBackend');
+            location         = $injector.get('$location');
+            $window          = $injector.get('$window');
+            $analytics       = $injector.get('$analytics');
+            ngProgressLite   = $injector.get('ngProgressLite');
 
             schema  = {};
             options = {};
             profile = {};
-
 
             spyOn(location, 'path').and.returnValue("/search");
 
@@ -44,9 +45,8 @@ describe('SearchCtrl', function (){
                 schema         : schema,
                 profile        : profile,
                 PatientSummary : PatientSummary,
-                $analytics: $analytics
+                $analytics     : $analytics
             });
-
 
         });});
 
@@ -120,6 +120,20 @@ describe('SearchCtrl', function (){
             });
             $scope.loadResults();
             $httpBackend.flush();
+        });
+
+        it('loadResults() should reset the progressbar if we error.', function() {
+            location.search({
+                query: "Bond",
+                page_number: 1
+            });
+
+            var expectedUrl = "/search/simple/?query=Bond&page_number=1";
+            $httpBackend.expectGET().respond(500);
+            spyOn(ngProgressLite, 'done');
+            $scope.loadResults();
+            $httpBackend.flush();
+            expect(ngProgressLite.done).toHaveBeenCalledWith();
         });
 
         it("should redirect to the search page", function(){

--- a/opal/static/js/opal/controllers/edit_item.js
+++ b/opal/static/js/opal/controllers/edit_item.js
@@ -104,11 +104,15 @@ angular.module('opal.controllers').controller(
                 if(!angular.equals($scope.the_episode.makeCopy(), $scope.episode)){
                     to_save.push($scope.the_episode.save($scope.episode));
                 }
-
-                $q.all(to_save).then(function() {
-                ngProgressLite.done();
-      			    $modalInstance.close(result);
-		        });
+                $q.all(to_save).then(
+                    function() {
+                        ngProgressLite.done();
+      			        $modalInstance.close(result);
+		            },
+                    function(){
+                        ngProgressLite.done();
+                    }
+                );
 	        };
 
             // Let's have a nice way to kill the modal.

--- a/opal/static/js/opal/controllers/edit_teams.js
+++ b/opal/static/js/opal/controllers/edit_teams.js
@@ -19,12 +19,17 @@ angular.module('opal.controllers').controller(
         // Save the teams.
         //
   	    $scope.save = function(result) {
-              ngProgressLite.set(0);
-              ngProgressLite.start();
-              episode.tagging[0].save($scope.editing.tagging).then(function() {
-                ngProgressLite.done();
+            ngProgressLite.set(0);
+            ngProgressLite.start();
+            episode.tagging[0].save($scope.editing.tagging).then(
+                function() {
+                    ngProgressLite.done();
       			    $modalInstance.close(result);
-  		    });
+  		        },
+                function() {
+                    ngProgressLite.done();
+                }
+            );
   	    };
 
         // Let's have a nice way to kill the modal.

--- a/opal/static/js/test/edit_item.controller.test.js
+++ b/opal/static/js/test/edit_item.controller.test.js
@@ -24,17 +24,17 @@ describe('EditItemCtrl', function (){
             $timeout       = $injector.get('$timeout');
             $modal         = $injector.get('$modal');
             ngProgressLite = $injector.get('ngProgressLite');
-            $rootScope = $injector.get('$rootScope');
+            $rootScope     = $injector.get('$rootScope');
             $modal         = $injector.get('$modal');
             opalTestHelper = $injector.get('opalTestHelper');
         });
 
-        episode = opalTestHelper.newEpisode($rootScope);
-        metadataCopy = opalTestHelper.getMetaData();
-        profile = opalTestHelper.getUserProfile();
+        episode       = opalTestHelper.newEpisode($rootScope);
+        metadataCopy  = opalTestHelper.getMetaData();
+        profile       = opalTestHelper.getUserProfile();
         referencedata = opalTestHelper.getReferenceData();
-        $scope = $rootScope.$new();
-        item = new Item(
+        $scope        = $rootScope.$new();
+        item          = new Item(
             {columnName: 'investigation'},
             episode,
             $rootScope.fields.investigation
@@ -55,8 +55,8 @@ describe('EditItemCtrl', function (){
             profile       : profile,
             episode       : episode,
             ngProgressLite: ngProgressLite,
-            referencedata: referencedata,
-            $analytics: $analytics
+            referencedata : referencedata,
+            $analytics    : $analytics
         });
 
     });
@@ -135,6 +135,18 @@ describe('EditItemCtrl', function (){
             callArgs = episode.save.calls.mostRecent().args;
             expect(callArgs.length).toBe(1);
             expect(callArgs[0]).toBe($scope.episode);
+        });
+
+        it('should cancel the progressbar if we fail to save', function() {
+            var deferred = $q.defer();
+            spyOn(ngProgressLite, 'done');
+            spyOn(item, 'save').and.callFake(function() {
+                return deferred.promise;
+            });
+            $scope.save('save');
+            deferred.reject("Failure !!!");
+            $scope.$digest();
+            expect(ngProgressLite.done).toHaveBeenCalledWith();
         });
 
     });

--- a/opal/static/js/test/edit_teams.controller.test.js
+++ b/opal/static/js/test/edit_teams.controller.test.js
@@ -4,7 +4,7 @@ describe('EditTeamsCtrl', function(){
     var $scope, $rootScope, $httpBackend, $window, $modal, $controller;
     var Episode;
     var UserProfile;
-    var modalInstance;
+    var modalInstance, ngProgressLite;
     var episode, opalTestHelper;
 
     beforeEach(function(){
@@ -12,14 +12,15 @@ describe('EditTeamsCtrl', function(){
         module('opal.test');
 
         inject(function($injector){
-            $httpBackend = $injector.get('$httpBackend');
-            $rootScope   = $injector.get('$rootScope');
-            $scope       = $rootScope.$new();
-            $window      = $injector.get('$window');
-            $controller  = $injector.get('$controller');
-            $modal       = $injector.get('$modal');
-            Episode      = $injector.get('Episode');
-            opalTestHelper = $injector.get('opalTestHelper');
+            $httpBackend     = $injector.get('$httpBackend');
+            $rootScope       = $injector.get('$rootScope');
+            $scope           = $rootScope.$new();
+            $window          = $injector.get('$window');
+            $controller      = $injector.get('$controller');
+            $modal           = $injector.get('$modal');
+            Episode          = $injector.get('Episode');
+            opalTestHelper   = $injector.get('opalTestHelper');
+            ngProgressLite   = $injector.get('ngProgressLite');
         });
 
         UserProfile = opalTestHelper.getUserProfileLoader();
@@ -30,7 +31,7 @@ describe('EditTeamsCtrl', function(){
         episode.tagging = [
                 {
                     save: function(a){
-                        return {then: function(fn) { fn(); }}
+                        return {then: function(fn, fn2) { fn(); }}
                     },
                     makeCopy: function(){
                       return {tropical: true};
@@ -83,6 +84,16 @@ describe('EditTeamsCtrl', function(){
             $scope.save('close');
             $rootScope.$apply();
             expect(modalInstance.close).toHaveBeenCalledWith('close');
+        });
+
+        it('should reset the progressbar if we error', function() {
+            spyOn(ngProgressLite, 'done');
+            episode.tagging[0].save = function(a){
+                        return {then: function(fn, fn2) { fn2(); }}
+                    }
+            $scope.save('close');
+            $rootScope.$apply();
+            expect(ngProgressLite.done).toHaveBeenCalledWith()
         });
 
     });


### PR DESCRIPTION
Notice that we fail to systematically ensure we're cleaning up after ourselves when we start a progressbar. 

This results in the occasional ghost progress bar we've seen on occasion.

To reproduce this pre this PR you can for instance introduce a `raise ValueError()` at the start of `opal.core.api.SubrecordViewSet.update` and attempt to edit a subrecord instance.

It would be better if we had failure handlers for all of our things that start progress bars which end them.

closes #352 