### PR TITLE
Update javascript indentation default for js-mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,2 +1,2 @@
 ((nil . ((tab-width . 4)
-         (js-indent-level . 4))))
+         (js-indent-level . 2))))


### PR DESCRIPTION
We should only have one, and be consistent...

If you're _very_ sure you want it to be 2, then this is the change that will update the Emacs default.

TBH I find it harder to read and crowded as compared to 4. Sure I could get used to it.

But pick one and stop moving whitespace back and forth would be good.