### PR TITLE
402 patient detail 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Misc Changes
 
-Fixes some instances of progressbars not being set if unexpected error states occur.
+Fixes some instances of progressbars not being reset if unexpected error states
+occur.
+
+Improves the rendering of patient detail pages where no patient with the ID from
+route params exits. (Displays a polite message instead of erroring.)
 
 ### 0.9.0 (Major Release)
 

--- a/opal/static/js/opal/controllers/patient_detail.js
+++ b/opal/static/js/opal/controllers/patient_detail.js
@@ -6,7 +6,9 @@ angular.module('opal.controllers').controller(
     ){
         $scope.profile = profile;
         $scope.patient = patient;
-        $scope.episode = patient.episodes[0];
+        if($scope.patient != null){
+            $scope.episode = patient.episodes[0];
+        }
         $scope.view = null;
 
         $scope.refresh = function(){
@@ -72,7 +74,8 @@ angular.module('opal.controllers').controller(
 			    $rootScope.state = 'normal';
 		    });
 	    };
-
-      $scope.initialise();
+        if($scope.patient != null){
+            $scope.initialise();
+        }
     }
 );

--- a/opal/static/js/opal/services/patient_loader.js
+++ b/opal/static/js/opal/services/patient_loader.js
@@ -23,7 +23,7 @@ angular.module('opal.services').factory('patientLoader', function(
       function(){
         // handle error better
         $window.alert('Patient could not be loaded');
-        deferred.resolve();
+        deferred.resolve(null);
     });
 
     return deferred.promise;

--- a/opal/static/js/test/patient_detail.controller.test.js
+++ b/opal/static/js/test/patient_detail.controller.test.js
@@ -1,138 +1,152 @@
 describe('PatientDetailCtrl', function(){
-    "use strict";
+  "use strict";
 
-    var $scope, $rootScope, $controller, $modal, $routeParams, $httpBackend;
-    var Flow, patientLoader, Episode, opalTestHelper;
-    var patient, controller, metadata, profile;
+  var $scope, $rootScope, $controller, $modal, $routeParams, $httpBackend;
+  var Flow, patientLoader, Episode, opalTestHelper;
+  var patient, controller, metadata, profile;
+  var mkcontroller;
 
+  beforeEach(function(){
+    module('opal');
+    module('opal.test');
+    patientLoader = jasmine.createSpy();
+
+    inject(function($injector){
+      $rootScope   = $injector.get('$rootScope');
+      $scope       = $rootScope.$new();
+      $controller  = $injector.get('$controller');
+      $modal       = $injector.get('$modal');
+      $routeParams = $injector.get('$routeParams');
+      $httpBackend = $injector.get('$httpBackend');
+      Episode      = $injector.get('Episode');
+      opalTestHelper = $injector.get('opalTestHelper');
+    });
+
+    // $rootScope.fields = fields;
+    // patient = {episodes: [new Episode(angular.copy(episodeData))] };
+    patient = opalTestHelper.newPatient($rootScope);
+    metadata = opalTestHelper.getMetaData();
+    profile = opalTestHelper.getUserProfile();
+
+    Flow = {exit: jasmine.createSpy().and.returnValue({
+      then: function(fn){ fn(); }
+    }) };
+
+    mkcontroller = function(patient){
+      controller = $controller('PatientDetailCtrl', {
+        $scope       : $scope,
+        $routeParams : $routeParams,
+        Flow         : Flow,
+        patient      : patient,
+        profile      : profile,
+        metadata     : metadata,
+        patientLoader: patientLoader
+      });
+    };
+    mkcontroller(patient);
+
+  });
+
+  describe('initialization', function(){
+
+    it('should set up state', function(){
+      expect($scope.patient).toEqual(patient)
+    });
+
+    it('should set up the metadata', function(){
+      expect($scope.metadata).toEqual(metadata);
+    });
+
+    it('should call switch_to_view', function() {
+      spyOn($scope, 'switch_to_view');
+      $routeParams.view = 'myview';
+      $scope.initialise();
+      expect($scope.switch_to_view).toHaveBeenCalledWith('myview');
+    });
+
+    it('should set the episode', function() {
+      spyOn($scope, 'switch_to_episode');
+      $routeParams.view = '123';
+      $scope.initialise();
+      expect($scope.switch_to_episode).toHaveBeenCalledWith(0);
+    });
+
+    it('should hoist the metaddata', function(){
+      expect($scope.metadata).toBe(metadata);
+    });
+
+    describe('with no patient', function() {
+
+      it('should not run initialize.', function() {
+        mkcontroller(null);
+        expect($scope.epsisode).toBe(undefined);
+      });
+
+    });
+
+  });
+
+  describe('switch_to_episode()', function() {
+
+    it('should switch to the episode', function() {
+      var mock_event = {preventDefault: jasmine.createSpy()};
+      $scope.switch_to_episode(0, mock_event);
+      expect($scope.view).toBe(null);
+      expect($scope.episode).toBe(patient.episodes[0]);
+    });
+
+  });
+
+  describe('refresh()', function(){
     beforeEach(function(){
-        module('opal');
-        module('opal.test');
-        patientLoader = jasmine.createSpy();
+      var nameChanged = opalTestHelper.getEpisodeData();
+      nameChanged.demographics[0].first_name = "Gerald";
+      patient = {
+        episodes: [new Episode(nameChanged)],
+        demographics: [nameChanged.demographics[0]]
+      };
 
-        inject(function($injector){
-            $rootScope   = $injector.get('$rootScope');
-            $scope       = $rootScope.$new();
-            $controller  = $injector.get('$controller');
-            $modal       = $injector.get('$modal');
-            $routeParams = $injector.get('$routeParams');
-            $httpBackend = $injector.get('$httpBackend');
-            Episode      = $injector.get('Episode');
-            opalTestHelper = $injector.get('opalTestHelper');
-        });
-
-        // $rootScope.fields = fields;
-        // patient = {episodes: [new Episode(angular.copy(episodeData))] };
-        patient = opalTestHelper.newPatient($rootScope);
-        metadata = opalTestHelper.getMetaData();
-        profile = opalTestHelper.getUserProfile();
-
-        Flow = {exit: jasmine.createSpy().and.returnValue({
-          then: function(fn){ fn(); }
-        }) };
-
-        controller = $controller('PatientDetailCtrl', {
-            $scope      : $scope,
-            $routeParams: $routeParams,
-            Flow        : Flow,
-            patient     : patient,
-            profile     : profile,
-            metadata    : metadata,
-            patientLoader: patientLoader
-        });
-
-    });
-
-    describe('initialization', function(){
-
-        it('should set up state', function(){
-            expect($scope.patient).toEqual(patient)
-        });
-
-        it('should set up the metadata', function(){
-            expect($scope.metadata).toEqual(metadata);
-        });
-
-        it('should call switch_to_view', function() {
-            spyOn($scope, 'switch_to_view');
-            $routeParams.view = 'myview';
-            $scope.initialise();
-            expect($scope.switch_to_view).toHaveBeenCalledWith('myview');
-        });
-
-        it('should set the episode', function() {
-            spyOn($scope, 'switch_to_episode');
-            $routeParams.view = '123';
-            $scope.initialise();
-            expect($scope.switch_to_episode).toHaveBeenCalledWith(0);
-        });
-
-        it('should hoist the metaddata', function(){
-            expect($scope.metadata).toBe(metadata);
-        });
-    });
-
-    describe('switch_to_episode()', function() {
-
-        it('should switch to the episode', function() {
-            var mock_event = {preventDefault: jasmine.createSpy()};
-            $scope.switch_to_episode(0, mock_event);
-            expect($scope.view).toBe(null);
-            expect($scope.episode).toBe(patient.episodes[0]);
-        });
-
-    });
-
-    describe('refresh()', function(){
-      beforeEach(function(){
-        var nameChanged = opalTestHelper.getEpisodeData();
-        nameChanged.demographics[0].first_name = "Gerald";
-        patient = {
-          episodes: [new Episode(nameChanged)],
-          demographics: [nameChanged.demographics[0]]
-        };
-
-        patientLoader.and.returnValue({
-          then: function(fn){
-            fn(patient);
-          }
-        });
-      });
-
-      it('should refresh the patient', function(){
-        $scope.refresh();
-        expect($scope.patient.demographics[0].first_name).toBe("Gerald");
-      });
-
-      it('should update the current episode on the scope', function(){
-        $scope.refresh();
-        expect($scope.episode.demographics[0].first_name).toBe("Gerald");
+      patientLoader.and.returnValue({
+        then: function(fn){
+          fn(patient);
+        }
       });
     });
 
-    describe('switch_to_view()', function() {
-
-        it('should switch', function() {
-            $scope.switch_to_view('wat');
-            expect($scope.view).toEqual('wat');
-        });
-
+    it('should refresh the patient', function(){
+      $scope.refresh();
+      expect($scope.patient.demographics[0].first_name).toBe("Gerald");
     });
 
-    describe('dischargeEpisode()', function() {
-
-        it('should should return null if readonly', function() {
-            profile.readonly = true;
-            expect($scope.dischargeEpisode()).toBe(null);
-        });
-
-        it('should call Flow.', function() {
-            $httpBackend.expectGET('/api/v0.1/userprofile/').respond({});
-            profile.readonly = false;
-            $scope.dischargeEpisode();
-            $rootScope.$apply();
-        });
-
+    it('should update the current episode on the scope', function(){
+      $scope.refresh();
+      expect($scope.episode.demographics[0].first_name).toBe("Gerald");
     });
+  });
+
+  describe('switch_to_view()', function() {
+
+    it('should switch', function() {
+      $scope.switch_to_view('wat');
+      expect($scope.view).toEqual('wat');
+    });
+
+  });
+
+  describe('dischargeEpisode()', function() {
+
+    it('should should return null if readonly', function() {
+      profile.readonly = true;
+      expect($scope.dischargeEpisode()).toBe(null);
+    });
+
+    it('should call Flow.', function() {
+      $httpBackend.expectGET('/api/v0.1/userprofile/').respond({});
+      profile.readonly = false;
+      $scope.dischargeEpisode();
+      $rootScope.$apply();
+    });
+
+  });
 
 });

--- a/opal/static/js/test/patient_loader.service.test.js
+++ b/opal/static/js/test/patient_loader.service.test.js
@@ -61,6 +61,7 @@ describe('patientLoader', function() {
     });
 
     describe('patient API errors', function() {
+
       it('should alert() the user', function() {
         $httpBackend.expectGET('/api/v0.1/patient/123/').respond(500);
         $httpBackend.expectGET('/api/v0.1/record/').respond({});
@@ -70,6 +71,17 @@ describe('patientLoader', function() {
         $rootScope.$apply();
         $httpBackend.flush();
       });
+
+      it('should resolve with null', function() {
+        $httpBackend.expectGET('/api/v0.1/patient/123/').respond(500);
+        $httpBackend.expectGET('/api/v0.1/record/').respond({});
+        patientLoader().then(function(patient){
+          expect(patient).toBe(null);
+        });
+        $rootScope.$apply();
+        $httpBackend.flush();
+      });
+
     });
 
     describe('No patient id found', function() {

--- a/opal/templates/patient_detail_base.html
+++ b/opal/templates/patient_detail_base.html
@@ -1,6 +1,17 @@
 {% load panels %}
 {% load forms %}
-<div class="container-fluid content-offset {% block container_classes %}{% endblock %}">
+<div ng-show="patient == null" class="container-fluid content-offset">
+  <h1 class="text-center content-offset">
+    Patient not found
+  </h1>
+  <p class="lead text-center content-offset">
+    We're sorry but we couldn't find the patient you're looking for.
+    <br />
+    Perhaps try searching for them instead?
+  </p>
+</div>
+<div class="container-fluid content-offset {% block container_classes %}{% endblock %}"
+     ng-hide="patient == null">
   <div class="panel panel-primary panel-container patient-detail {% block panel_classes %}{% endblock %}">
     <!-- Default panel contents -->
     <div class="panel-heading patient-detail-heading">


### PR DESCRIPTION
All about having a friendly failure mode for the case when a user goes to a detail page that doesn't exist e.g. http://localhost:8000/#/patient/4009999994333333999292929 

(Refs #402 but doesn't close it because we're waiting on a merge to the branch that introduces the 9.1 Changelog section)