### PR TITLE
Fix path errors and markdown errors when building docs

### DIFF
--- a/doc/docs/guides/topic-guides.md
+++ b/doc/docs/guides/topic-guides.md
@@ -53,7 +53,7 @@ A list of all available topic guides.
 ### Working on Opal itself
 |||
 |--|--|
-[Contributing](contributing.md) | Contributing to Opal
+[Contributing](CONTRIBUTING.md) | Contributing to Opal
 [Development environment](development_environment.md) | Setting up the Opal development environment
 
 ### Other Guides

--- a/doc/docs/reference/reference_guides.md
+++ b/doc/docs/reference/reference_guides.md
@@ -58,7 +58,7 @@ The following reference guides are available:
 |
 -|-
 [Settings](settings.md) | Opal settings
-[Changelog](changelog.md) | Opal Changelog
+[Changelog](CHANGELOG.md) | Opal Changelog
 [Upgrading](upgrading.md) | Upgrading between Opal versions
 [Javascript dependencies](javascript/javascript_dependencies.md)| External javascript libraries available |
 [Testing](testing.md) | Testing

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -45,7 +45,7 @@ pages:
       - Django Admin: guides/django_admin.md
 
       # Working on Opal itself
-      - Contributing: guides/contributing.md
+      - Contributing: guides/CONTRIBUTING.md
       - Development environment: guides/development_environment.md
 
       # Other guides
@@ -96,7 +96,7 @@ pages:
 
       # Misc
       - Settings: reference/settings.md
-      - Changelog: reference/changelog.md
+      - Changelog: reference/CHANGELOG.md
       - Testing: reference/testing.md
       - Javascript dependencies: reference/javascript/javascript_dependencies.md
       - Upgrading: reference/upgrading.md

--- a/doc/rtd-requirements.txt
+++ b/doc/rtd-requirements.txt
@@ -1,1 +1,2 @@
-mkdocs
+mkdocs==0.15.3
+markdown==2.6.6


### PR DESCRIPTION
Some of the files in the repository root such as CHANGELOG.md and CONTRIBUTING.md, which are symlinked to from the doc directory were referenced using the wrong case in the documentation.

This meant mkdocs build errors when building docs on a case-sensitive file system (Linux in this case).

This PR fixes the case mismatches across all of the documentation files, as well as pinning the version of Markdown and mkdocs to prevent markdown table formatting errors. (Further issue to be raised about these formatting errors)