### PR TITLE
This should really blank the NG-App by default

### DIFF
--- a/opal/templates/static_page.html
+++ b/opal/templates/static_page.html
@@ -1,4 +1,5 @@
 {% extends 'opal.html' %}
+{% block ngapp %}{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
This was from the theming work

I don't think it actually makes sense without doing this by default.

Idea is that you can extend this rather than `opal.html` if you're just going to render a non-angular page.

Currently undocumented as we're not definite on the API and don't want to do warnings etc... 

But required for further changes which use this...

