### PR TITLE
We shouldn't blow up in {% menu %} if there happens to be no user in Context()

### DIFF
--- a/opal/templatetags/menus.py
+++ b/opal/templatetags/menus.py
@@ -17,7 +17,7 @@ def menu(context):
     """
     context = copy.copy(context)
     app = application.get_app()
-    menu = app.get_menu(user=context['user'])
+    menu = app.get_menu(user=context.get('user', None))
 
     context.dicts.append({
         'menu': menu,

--- a/opal/tests/test_templatetags_menus.py
+++ b/opal/tests/test_templatetags_menus.py
@@ -15,3 +15,7 @@ class MenuTestCase(test.OpalTestCase):
     def test_menu_passes_through_menu(self):
         ctx = menus.menu(Context({'user': MagicMock(name='User')}))
         self.assertIsInstance(ctx['menu'], Menu)
+
+    def test_menu_will_allow_there_to_be_no_user(self):
+        ctx = menus.menu(Context({}))
+        self.assertIsInstance(ctx['menu'], Menu)


### PR DESCRIPTION
This shouldn't really ever happen.
But it can happen.
And if it does (something's going wrong with context processor initialization probably), you never want the error to be raised here.