### PR TITLE
Episode categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ the subrecord.
 
 When you delete a user, it will no longer delete all related episodes and subrecords
 
+#### Episode Category stages
+
+Episode categories now enforce a set of valid `Episode.stage` values.
+`EpisodeCategory` now includes the `.get_stages()` and `.has_stage(stage)` methods,
+while `Episode` has a `set_stage` setter which is used by the JSON API.
+
 #### lookuplists.lookuplists
 
 Adds the utility generator `lookuplists.lookuplists()` which wil yield every lookuplist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ while `Episode` has a `set_stage` setter which is used by the JSON API.
 Adds the utility generator `lookuplists.lookuplists()` which wil yield every lookuplist
 currently available.
 
+#### Discoverable.filter()
+
+Disoverable features now have a `filter` method which allows you to filter features
+with matching attributes.
+
 #### Missing consistency token errors
 
 `.update_from_dict()` will now raise the new error

--- a/doc/docs/guides/discoverable.md
+++ b/doc/docs/guides/discoverable.md
@@ -57,27 +57,27 @@ We can make our feature sortable via an `order` property by including
  `discoverable.SortableFeature` as a parent class. This will ensure that `MyFeature.list()`
  respects the `.order` number of any subclass.
 
+```python
+class MyFeature(discoverable.DiscoverableFeature,
+                discoverable.SortableFeature):
+    module_name = 'myfeature'
 
-    class MyFeature(discoverable.DiscoverableFeature,
-                     discoverable.SortableFeature):
-         module_name = 'myfeature'
+class ThirdFeature(MyFeature):
+    order = 3
 
-    class ThirdFeature(MyFeature):
-        order = 3
+class FirstFeature(MyFeature):
+    order = 1
 
-    class FirstFeature(MyFeature):
-        order = 1
+class SecondFeature(MyFeature):
+    order = 2
 
-    class SecondFeature(MyFeature):
-        order = 2
+for f in MyFeature.list():
+    print f, f.order
 
-    for f in MyFeature.list():
-        print f.order, f
-
-    # <class '*.*.FirstFeature'>, 1
-    # <class '*.*.SecondFeature'>, 2
-    # <class '*.*.ThirdFeature'>, 3
-
+# <class '*.*.FirstFeature'>, 1
+# <class '*.*.SecondFeature'>, 2
+# <class '*.*.ThirdFeature'>, 3
+```
 
 ### Restrictable Features
 

--- a/doc/docs/guides/episodes.md
+++ b/doc/docs/guides/episodes.md
@@ -1,0 +1,94 @@
+# Opal Episodes
+
+In Opal a Patient may have one or many Episodes. An Episode contains some metadata
+such as a start and end date, and the type of episode. This may be an inpatient
+stay, an outpatient treatment, a telephone consultation  - or any other arbitrarily
+defined period of care.
+
+
+## Episode Categories
+
+An episode must have a related category. An Opal `EpisodeCategory` is a discoverable
+subclass of `opal.core.episodes.EpisodeCategory` - such as `InpatientEpisode`,
+`OutpatientEpisode` or `LiaisonEpisode`.
+
+You can access the current category of an episode via the `category` property, while
+it is represented in the database in the field `category_name` which will contain
+the `display_name` attribute of the relevant category.
+
+```python
+episode = patient.episode_set.first()
+print episode.category
+# <opal.core.episode.InpatientEpisode object>
+
+print episode.category.display_name
+# "Inpatient"
+
+print episode.category_name
+# "Inpatient"
+```
+
+## Detail templates
+
+The category of an episode determines which template will be used to display it
+on the detail page for the patient. This template is determined by looking up
+the `detail_template` attribute of the `EpisodeCategory`.
+
+```python
+episode.category
+print episode.category
+# <opal.core.episode.InpatientEpisode object>
+
+print episode.category.detail_template
+# detail/inpatient.html
+```
+
+## Default Category
+
+The default category of episodes in an Opal application is set by the
+[OpalApplication](../reference/opal_application) object's default_episode_category
+property.
+
+```python
+class Application(application.OpalApplication):
+    default_episode_category = MyCategory.display_name
+```
+
+## Episode stages
+
+An Episode will frequently consist of a number of possible stages. For instance,
+for an inpatient episode, a patient will first be an inpatient, and then an
+be discharged, with an optional interim follow up stage for inpatients who have been
+discharged but requrie further follow up.
+
+Opal stores the stage of an episode as a string in the `stage` property of an
+`Episode`. The valid possible stages for a category are accessed from the
+`get_stages` method of the category.
+
+```
+episode.catetory.get_stages()
+# ['Inpatient', 'Followup', 'Discharged']
+
+episode.category.has_stage('Followup')
+# True
+```
+
+## Defining your own EpisodeCategory
+
+As EpisodeCategory is a [discoverable](discoverable) we can define our own to
+meet custom requirements.
+
+Episode categories should be defined in a file named `episode_categories` of
+your application or plugin.
+
+```python
+# yourapp/episode_categories.py
+
+from opal.core import episodes
+
+
+class DropInClinicEpisode(episodes.EpisodeCategory):
+    display_name = "Drop-in clinic"
+    detail_template = "detail/drop_in.html"
+
+```

--- a/doc/docs/guides/topic-guides.md
+++ b/doc/docs/guides/topic-guides.md
@@ -16,8 +16,9 @@ A list of all available topic guides.
 ### Data and Business Logic
 
 |||
-|---------------------------|-------------------------------------------------------------------------------|
+|---------------------------|--------------------------------------------------------------------|
 |[Data Model](datamodel.md) | How Opal models clinical reality|
+|[Episodes](episodes)|Opal Episodes and how to customise them|
 |[Core Clinical Model](archetypes.md)| The core clinical data model available to Opal applications|
 |[Reference data](referencedata.md) | Canonical coded terms and reference data|
 |[App metadata](metadata.md) | Working with Metadata on the front end  |

--- a/doc/docs/reference/core_discoverable.md
+++ b/doc/docs/reference/core_discoverable.md
@@ -1,0 +1,157 @@
+# opal.core.discoverable
+
+The `opal.core.discoverable` module contans base discoverable classes for creating
+features which can be re-used and subcalssd.
+
+## DiscoverableFeature
+
+The base discoverable class which provides functionality to all discoverables.
+
+**DiscoverableFeature properties**
+
+### DiscoverableFeature.module_name
+
+The name of the python module in which Opal will look for instances of this
+discoverable. For instance in the following feature, Opal would look in every
+installed app at `app/ciao.py` for subclasses of `Greeting`, even if that module
+had not been directly imported already.
+
+```python
+from opal.core import discoverable
+
+class Greeting(discoverable.DiscoverableFeature):
+  module_name = 'ciao'
+```
+
+### DiscoverableFeature.display_name
+
+The human readable name for an instance of a discoverable. Use this in the UI
+when showing the discoverable to users.
+
+### DiscoverableFeature.slug
+
+The slug for this discoverable used in URLs. Note that Opal internally useses
+the `get_slug` method below to allow more dynamic slugs.
+
+** DiscoverableFeature classmethods **
+
+### DiscoverableFeature.is_valid()
+
+Stub function that is called at class definition to determine whether an instance
+is valid. Useful for enforcing business logic and expectations for third party
+features. Expected to raise an exception if something is wrong.
+
+### DiscoverableFeature.get_slug()
+
+Return the slug for this feature. Defaults to returning the `slug` property if
+it is set, or running a slugify function on the `display_name`. If neither is
+set it will raise a ValueError.
+
+```python
+MyFeature.get_slug()
+# -> "my-feature"
+```
+
+### DiscoverableFeature.list()
+
+Return a generator that yields all implementations of a discoverable.
+
+```
+for g in Greeting.list():
+    print g.display_name
+
+"Bonjour"
+"Hola"
+"Namaste"
+"Salaam"
+```
+
+### DiscoverableFeature.filter(**kwargs)
+
+Find instances of a feature based on the value of their attributes. You may pass
+attributes of features as keyword arguments. Returns a list of matching features.
+
+```python
+Greeting.filter(module_name='ciao') # Essentially the same as .list()
+
+Greeting.filter(slug="bonjour", display_name="Bonjour")
+# -> [BonjourGreeting]
+```
+
+## SortableFeature
+
+A mixin class that provides ordering for features which will be respected
+by both `list()` and `filter()`.
+
+** Properties **
+
+### SortableFeature.order
+
+An integer which is used to sort features.
+
+** SortableFeature classmethods **
+
+### SortableFeature.list()
+
+Returns instances of the feature orderd by `.order`
+
+```python
+class Greeting(discoverable.DiscoverableFeature,
+               discoverable.SortableFeature):
+    module_name='ciao'
+
+class Namaste(Greeting):
+    order = 2
+
+class Hello(Greeting):
+    order = 32098239021
+
+class Bonjour(Greeting):
+    order = 1
+
+for f in Greeting.list():
+    print f, f.order
+
+# <class '*.*.Bonjour'>, 1
+# <class '*.*.Namaste'>, 2
+# <class '*.*.Hello'>, 3
+
+```
+
+## RestrictableFeature
+
+A mixin class that provides an interface for restricting access to features based on
+user.
+
+```python
+class Greeting(discoverable.DiscoverableFeature,
+               discoverable.RestrictableFeature):
+    module_name='ciao'
+
+```
+** RestrictableFeature classmethods **
+
+## RestrictableFeature.for_user(user)
+
+Generator method that yields all instances of this discoverable which are visible to
+a given user.
+
+```
+for f in Greeting.for_user(user):
+    print f
+
+# <class '*.*.Bonjour'>
+# <class '*.*.Namaste'>
+# <class '*.*.Hello'>
+```
+
+## RestrictableFeature.visible_to(user)
+
+Predicate function used to determine whehter in individual feature should be visible
+to a given user. Defaults to simply returning True.
+
+Features may override this to provide restricted access as required.
+
+```python
+Hello.visible_to(user) # -> True
+```

--- a/doc/docs/reference/episode.md
+++ b/doc/docs/reference/episode.md
@@ -8,7 +8,7 @@ liaison, an appointment at a clinic, or any other arbitrarily defined period of 
 
 ### Episode.category
 
-The category of this episode - e.g. inpatient, outpatient et cetera.
+The [category](episode_categories) of this episode - e.g. inpatient, outpatient et cetera.
 This defaults to whatever is set on your application's subclass of
 `opal.core.application.OpalApplication` - which itself defaults to 'inpatient'.
 

--- a/doc/docs/reference/episode.md
+++ b/doc/docs/reference/episode.md
@@ -1,42 +1,42 @@
-## opal.models.Episode
+# opal.models.Episode
 
-The `opal.models.Episode` class represents an episode of care for a patient. This can be either
-an inpatient stay, an outpatient treatment, a telephone liaison, an appointment at a clinic,
-or any other arbitrarily defined period of care.
+The `opal.models.Episode` class represents an episode of care for a patient.
+This can be either an inpatient stay, an outpatient treatment, a telephone
+liaison, an appointment at a clinic, or any other arbitrarily defined period of care.
 
-### Fields
+## Fields
 
-#### Episode.category
+### Episode.category
 
 The category of this episode - e.g. inpatient, outpatient et cetera.
 This defaults to whatever is set on your application's subclass of
 `opal.core.application.OpalApplication` - which itself defaults to 'inpatient'.
 
-#### Episode.patient
+### Episode.patient
 
 A foreign key relationship to the patient for whom this episode concerns.
 
-#### Episode.active
+### Episode.active
 
 A boolean to provide a quick lookup for whether this is an active or closed episode.
 
-#### Episode.start
+### Episode.start
 
 This should be the start of the episode. If this is an inpatient episode, the date of admission.
 
-#### Episode.end
+### Episode.end
 
 This should be the end of the episode. If this is an inpatient episode, the date of discharge.
 
-#### Episode.consistency_token
+### Episode.consistency_token
 
 A (automatically generated) hash of the above fields. This is used for detecting concurrent edits.
 
-### Methods
+## Methods
 
 The Episode model has the following methods:
 
-#### Episode.to_dict
+### Episode.to_dict
 
 Return a dictionary of field value pairs for this episode
 
@@ -51,7 +51,7 @@ Keywords:
 * `shallow` Boolean to indicate whether we want just this episode, or also a sorted set of
 previous and subsequent episodes
 
-#### Episode.get_tag_names
+### Episode.get_tag_names(user)
 
 
 Arguments:
@@ -64,7 +64,7 @@ Return the current active tag names for this Episode as strings.
     # ['mine', 'infectioncontrol']
 
 
-#### Episode.set_tag_names
+### Episode.set_tag_names(tag_names, user)
 
 
 Arguments:
@@ -78,7 +78,7 @@ Set tags for this Episode.
 episode.set_tag_names(['mine', 'infectioncontrol'], user)
 ```
 
-#### Episode.set_tag_names_from_tagging_dict
+### Episode.set_tag_names_from_tagging_dict(tagging_dict, user)
 
 Arguments:
 
@@ -92,12 +92,23 @@ Set tags for this Episode.
 episode.set_tag_names_from_tagging_dict({'inpatient': True}, user)
 ```
 
-### Manager
+### Episode.set_stage(stage, user, data)
+
+Setter function for episode stage. Will validate that the stage given is
+valid for the current `EpisodeCategory` and raise `ValueError` if it is invalid.
+
+```python
+episode.set_stage('Discharged', user, {})
+episode.stage
+# -> 'Discharged'
+```
+
+## Manager
 
 The custom manager for Episodes has the following methods:
 
 
-#### Episode.objects.serialised()
+### Episode.objects.serialised()
 
 Return a set of serialised episodes.
 
@@ -113,12 +124,12 @@ Keywords:
 * `historic_tags` A boolean to indicate whether the user desires historic or just current tags to
 be serialised
 
-#### Episode.objects.search
+### Episode.objects.search
 
 As a useful utility, the episode manager has a search method that will search on first name, last name and/or hospital number, under the hood it uses [Patient search](patient.md#patientobjectssearch)
 
 
-### opal.core.api.EpisodeViewSet
+## opal.core.api.EpisodeViewSet
 
 Gives you an api for create/update/list/retrieve apis for episodes. Its recommended that you use [opal.core.patient_lists](patient_list.md) rather than the list api, as this gives you more flexibility.
 

--- a/doc/docs/reference/episode_categories.md
+++ b/doc/docs/reference/episode_categories.md
@@ -2,8 +2,8 @@
 
 ## EpisodeCategory
 
-Opal Episodes have an associated category. These categories are implemented as subclasses
-of `opal.core.episodes.EpisodeCategory`. This class is an Opal
+Opal [Episodes](../guides/episodes.md) have an associated category. These categories are
+implemented as subclasses of `opal.core.episodes.EpisodeCategory`. This class is an Opal
 [DiscoverableFeature](../guides/discoverable.md) and thus inherits all of the core
 Discoverable API.
 

--- a/doc/docs/reference/episode_categories.md
+++ b/doc/docs/reference/episode_categories.md
@@ -47,6 +47,24 @@ InpatientEpisode.episode_visible_to(episode, user)
 
 ** Methods **
 
+### EpisodeCategory.get_stages()
+
+Returns a list of stages for this category as strings.
+
+```python
+InpatientEpisode(episode).get_stages()
+# -> ['Inpatient', 'Followup', 'Discharged']
+```
+
+### EpisodeCategory.has_stage(stage)
+
+Predicate function to determine whether a string is a valid stage for this category.
+
+```python
+InpatientEpisode(episode).has_stage('Inpatient')
+# -> True
+```
+
 ## InpatientEpisode
 
 This is the default EpisodeCategory imlpementation - applications started with Opal's

--- a/doc/docs/reference/episode_categories.md
+++ b/doc/docs/reference/episode_categories.md
@@ -1,23 +1,54 @@
-## opal.core.episodes
-
+# opal.core.episodes
 
 ## EpisodeCategory
 
 Opal Episodes have an associated category. These categories are implemented as subclasses
-of `opal.core.episodes.EpisodeCategory`. This class is an Opal [DiscoverableFeature](../guides/discoverable.md)
-and thus inherits all of the core Discoverable API.
+of `opal.core.episodes.EpisodeCategory`. This class is an Opal
+[DiscoverableFeature](../guides/discoverable.md) and thus inherits all of the core
+Discoverable API.
 
 The category of any episode can be accessed as the `.category` property of any `Episode` instance.
 
-### Properties
+An episode category must be initialized with an instance of an episode.
 
-#### EpisodeCategory.detail_template
+```python
+from opal.core.episodes import InpatientEpisode
 
-This is the template used within the [Patient Detail View](../guides/patient_detail_views.md) to display
-information about episodes of this category.
+category = InpatientEpisode(episode)
+```
+
+** Properties **
+
+### EpisodeCategory.detail_template
+
+This is the template used within the [Patient Detail View](../guides/patient_detail_views.md)
+to display information about episodes of this category.
+
+### EpisodeCategory.stages
+
+A list of strings that are valid values for `Episode.stage` for this category.
+
+** Classmethods **
+
+### EpisodeCategory.episode_visible_to(episode, user)
+
+Predidcate function to determine whether an episode of this category is visible
+to a particular user.
+
+The default implementation will return True unless `UserProfile.restricted_only` is set to
+True. (In which case this user should not see any elements which are visible 'by default' for
+this application.)
+
+```python
+InpatientEpisode.episode_visible_to(episode, user)
+
+# -> True
+```
+
+** Methods **
 
 ## InpatientEpisode
 
-This is the default EpisodeCategory imlpementation - applications started with Opal's scaffolding
-scripts will use this as the `OpalApplication.default_episode_category`. It sets the detail template to
-`detail/inpatient.html`
+This is the default EpisodeCategory imlpementation - applications started with Opal's
+scaffolding scripts will use this as the `OpalApplication.default_episode_category`.
+It sets the detail template to `detail/inpatient.html`

--- a/doc/docs/reference/opal_application.md
+++ b/doc/docs/reference/opal_application.md
@@ -27,8 +27,8 @@ Properties available on an OpalApplication:
 
 #### OpalApplication.default_episode_category
 
-The default category is 'Inpatient', but can be overridden in the
-[OpalApplication](opal_application.md) subclass for your implementation.
+The default category is 'Inpatient', but can be overridden in the OpalApplication
+subclass for your implementation.
 
 #### OpalApplication.angular_module_deps
 

--- a/doc/docs/reference/reference_guides.md
+++ b/doc/docs/reference/reference_guides.md
@@ -24,6 +24,7 @@ The following reference guides are available:
 [opal.core.log](loggers.md)| Log Helpers - custom email error loggers
 [opal.core.fields](core_fields)| Field helpers - custom field types and utility functions|
 [opal.core.lookuplists](core_lookuplists.md) | Utilities for working with lookuplists |
+[opal.core.discoverable](core_discoverable.md) | Reusable feature groups for plugins and applications |
 
 ### Angular Services
 |

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -72,6 +72,7 @@ pages:
       - Log: reference/loggers.md
       - Fields: reference/core_fields.md
       - Lookuplists: reference/core_lookuplists.md
+      - Discoverable: reference/core_discoverable.md
 
       # Angular Services
       - reference/javascript/patient_service.md

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -21,6 +21,7 @@ pages:
 
       # Data and business logic
       - Data Model: guides/datamodel.md
+      - Episodes: guides/episodes.md
       - Archetypes: guides/archetypes.md
       - Referencedata: guides/referencedata.md
       - Metadata: guides/metadata.md

--- a/opal/core/discoverable.py
+++ b/opal/core/discoverable.py
@@ -120,6 +120,9 @@ class DiscoverableFeature(with_metaclass(DiscoverableMeta, object)):
 
 
 class SortableFeature(object):
+    """
+    Mixin class to provide ordering for features
+    """
     module_name = None
 
     @classmethod

--- a/opal/core/discoverable.py
+++ b/opal/core/discoverable.py
@@ -99,6 +99,25 @@ class DiscoverableFeature(with_metaclass(DiscoverableMeta, object)):
         raise ValueError('No {0} implementation with slug {1}'.format(
             klass, name))
 
+    @classmethod
+    def filter(klass, *args, **kwargs):
+        """
+        Return all matching instances of a feature based on a Django
+        Queryset-like interface.
+        """
+        def feature_filter(feature):
+            match = True
+            for attribute in kwargs:
+                if not hasattr(feature, attribute):
+                    msg = "Invalid Query: At least one {0} implementation " \
+                          "does not have a {1} attribute."
+                    raise ValueError(msg.format(klass, attribute))
+                if getattr(feature, attribute) != kwargs[attribute]:
+                    match = False
+            return match
+
+        return [f for f in klass.list() if feature_filter(f)]
+
 
 class SortableFeature(object):
     module_name = None

--- a/opal/core/episodes.py
+++ b/opal/core/episodes.py
@@ -73,6 +73,7 @@ class InpatientEpisode(EpisodeCategory):
         'Discharged'
     ]
 
+
 class OutpatientEpisode(EpisodeCategory):
     display_name = 'Outpatient'
     stages       = [

--- a/opal/core/episodes.py
+++ b/opal/core/episodes.py
@@ -1,7 +1,7 @@
 """
 Opal Episode categories
 
-An episode of care in OPAL can be one of many things:
+An episode of care in Opal can be one of many things:
 
 An inpatient admission
 A course of outpatient treatment
@@ -12,7 +12,7 @@ A research study enrollment
 (Non exhaustive list)
 
 An Episode category has various properties it can use to customise the way
-episodes of it's category behave in OPAL applications - for instance:
+episodes of it's category behave in Opal applications - for instance:
 
 Display
 Permissions
@@ -28,6 +28,7 @@ class EpisodeCategory(DiscoverableFeature):
     module_name     = "episode_categories"
     display_name    = None
     detail_template = None
+    stages          = []
 
     @classmethod
     def episode_visible_to(kls, episode, user):
@@ -49,15 +50,40 @@ class EpisodeCategory(DiscoverableFeature):
     def __init__(self, episode):
         self.episode = episode
 
+    def get_stages(self):
+        """
+        Return the list of string stages for this category
+        """
+        return [s for s in self.stages]
+
+    def has_stage(self, stage):
+        """
+        Predicate function to determine whether STAGE is a valid stage
+        for this category.
+        """
+        return stage in self.get_stages()
+
 
 class InpatientEpisode(EpisodeCategory):
     display_name    = 'Inpatient'
     detail_template = 'detail/inpatient.html'
-
+    stages          = [
+        'Inpatient',
+        'Followup',
+        'Discharged'
+    ]
 
 class OutpatientEpisode(EpisodeCategory):
     display_name = 'Outpatient'
+    stages       = [
+        'Outpatient',
+        'Discharged'
+    ]
 
 
 class LiaisonEpisode(EpisodeCategory):
     display_name = 'Liaison'
+    stages       = [
+        'Review',
+        'Unfollow'
+    ]

--- a/opal/models.py
+++ b/opal/models.py
@@ -762,6 +762,21 @@ class Episode(UpdatesFromDictMixin, TrackedModel):
         """
         return self.category.episode_visible_to(self, user)
 
+    def set_stage(self, stage, user, data):
+        """
+        Setter for Episode.stage
+
+        Validates that the stage being set is appropriate for the category
+        and raises ValueError if not.
+        """
+        if not self.category.has_stage(stage):
+            if stage is not None:
+                msg = "Can't set stage to {0} for {1} Episode".format(
+                    stage, self.category.display_name
+                )
+                raise ValueError(msg)
+        self.stage = stage
+
     def set_tag_names(self, tag_names, user):
         """
         1. Set the episode.active status

--- a/opal/models.py
+++ b/opal/models.py
@@ -749,7 +749,9 @@ class Episode(UpdatesFromDictMixin, TrackedModel):
     @property
     def category(self):
         from opal.core import episodes
-        category = episodes.EpisodeCategory.get(self.category_name.lower())
+        category = episodes.EpisodeCategory.filter(
+            display_name=self.category_name
+        )[0]
         return category(self)
 
     def visible_to(self, user):

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -821,6 +821,41 @@ class EpisodeTestCase(OpalTestCase):
         self.assertEqual(['micro'], tags)
         self.assertEqual(1, len(tags))
 
+    def test_can_set_stage(self):
+        self.mock_request.data = {
+            "tagging"      : { "micro":True },
+            "start"        : "14/01/2015",
+            "stage"        : "Inpatient",
+            "demographics" : {
+                "hospital_number": "9999000999",
+            },
+            "location"     : {
+                "ward": "West",
+                "bed" : "7"
+            }
+        }
+        response = api.EpisodeViewSet().create(self.mock_request)
+        patient = models.Patient.objects.get(
+            demographics__hospital_number="9999000999")
+        episode = patient.episode_set.get()
+        self.assertEqual('Inpatient', episode.stage)
+
+    def test_cant_set_invalid_stage(self):
+        self.mock_request.data = {
+            "tagging"      : { "micro":True },
+            "start"        : "14/01/2015",
+            "stage"        : "Whoops",
+            "demographics" : {
+                "hospital_number": "9999000999",
+            },
+            "location"     : {
+                "ward": "West",
+                "bed" : "7"
+            }
+        }
+        with self.assertRaises(ValueError):
+            response = api.EpisodeViewSet().create(self.mock_request)
+
     def test_update(self):
         patient, episode = self.new_patient_and_episode_please()
         self.assertEqual(None, episode.start)

--- a/opal/tests/test_core_discoverable.py
+++ b/opal/tests/test_core_discoverable.py
@@ -136,6 +136,47 @@ class DiscoverableFeatureTestCase(OpalTestCase):
     def test_get_exists(self):
         self.assertEqual(RedColour, ColourFeature.get('red'))
 
+    def test_filter(self):
+        self.assertEqual(
+            [BlueColour],
+            ColourFeature.filter(display_name='Blue')
+        )
+
+    def test_filter_returns_many(self):
+        self.assertEqual(
+            [BlueColour, RedColour, SeaGreenColour],
+            ColourFeature.filter(module_name='colours')
+        )
+
+    def test_filter_not_an_attr(self):
+        with self.assertRaises(ValueError):
+            ColourFeature.filter(notarealthing='Homeopathy')
+
+    def test_filter_many_attributes(self):
+        self.assertEqual(
+            [MySlugFeature],
+            SlugFeature.filter(
+                slug='my-slug',
+                display_name='My Slug Defined Slug'
+            )
+        )
+
+    def test_filter_no_results(self):
+        self.assertEqual(
+            [],
+            SlugFeature.filter(
+                slug='lol-nobody-would-choose-this-as-a-slug',
+            )
+        )
+
+    def test_filter_many_attributes_one_not_an_attr(self):
+        self.assertEqual(
+            [],
+            SlugFeature.filter(
+                slug='not-my-slug',
+                display_name='My Slug Defined Slug'
+            )
+        )
 
     def test_abstract_discoverable(self):
         class A(discoverable.DiscoverableFeature):

--- a/opal/tests/test_core_episodes.py
+++ b/opal/tests/test_core_episodes.py
@@ -21,17 +21,68 @@ class EpisodeCategoryTestCase(test.OpalTestCase):
         )
 
     def test_episode_categories(self):
-        self.assertIn(episodes.InpatientEpisode, episodes.EpisodeCategory.list())
+        self.assertIn(
+            episodes.InpatientEpisode, episodes.EpisodeCategory.list()
+        )
 
     def test_visible_to(self):
         self.assertTrue(
-            episodes.InpatientEpisode.episode_visible_to(self.inpatient_episode, self.user))
+            episodes.InpatientEpisode.episode_visible_to(
+                self.inpatient_episode, self.user)
+        )
 
     def test_visible_to_restricted_only(self):
         self.assertFalse(
-            episodes.InpatientEpisode.episode_visible_to(self.inpatient_episode,
-                                                         self.restricted_user)
+            episodes.InpatientEpisode.episode_visible_to(
+                self.inpatient_episode,
+                self.restricted_user)
         )
 
     def test_for_category(self):
-        self.assertEqual(episodes.InpatientEpisode, episodes.EpisodeCategory.get('inpatient'))
+        self.assertEqual(episodes.InpatientEpisode,
+                         episodes.EpisodeCategory.get('inpatient'))
+
+    def test_get_stages(self):
+        stages = [
+            'Inpatient',
+            'Followup',
+            'Discharged'
+        ]
+        category = episodes.InpatientEpisode(self.inpatient_episode)
+        self.assertEqual(stages, category.get_stages())
+
+    def test_get_stages_unchanged(self):
+        stages = [
+            'Inpatient',
+            'Followup',
+            'Discharged'
+        ]
+        category = episodes.InpatientEpisode(self.inpatient_episode)
+        stages1 = category.get_stages()
+        stages1.append('hahhahahaha')
+        self.assertEqual(stages, category.get_stages())
+
+    def test_has_stage_true(self):
+        category = episodes.InpatientEpisode(self.inpatient_episode)
+        self.assertTrue(category.has_stage('Inpatient'))
+
+    def test_has_stage_case_sensitive(self):
+        category = episodes.InpatientEpisode(self.inpatient_episode)
+        self.assertFalse(category.has_stage('inpatient'))
+
+    def test_has_stage_false(self):
+        category = episodes.InpatientEpisode(self.inpatient_episode)
+        self.assertFalse(category.has_stage('Airegin'))
+
+    def test_can_monkeypatch_stages(self):
+
+        class ButterflyEpisode(episodes.EpisodeCategory):
+            display_name = 'Butterfly'
+            stages       = [
+                'Caterpillar',
+                'Cocoon',
+            ]
+
+        ButterflyEpisode.stages.append('Butterfly')
+
+        self.assertTrue(ButterflyEpisode(None).has_stage('Butterfly'))

--- a/opal/tests/test_episode.py
+++ b/opal/tests/test_episode.py
@@ -20,7 +20,7 @@ class EpisodeTest(OpalTestCase):
 
     def setUp(self):
         self.patient, self.episode = self.new_patient_and_episode_please()
-        self.episode.stage = "Active TB"
+        self.episode.stage = "Inpatient"
         self.episode.save()
 
     def test_singleton_subrecord_created(self):
@@ -40,6 +40,26 @@ class EpisodeTest(OpalTestCase):
 
     def test_visible_to(self):
         self.assertTrue(self.episode.visible_to(self.user))
+
+    def test_set_stage(self):
+        self.episode.set_stage('Discharged', self.user, {})
+        self.assertEqual('Discharged', self.episode.stage)
+
+    def test_set_stage_for_none(self):
+        self.episode.set_stage(None, self.user, {})
+        self.assertEqual(None, self.episode.stage)
+
+    def test_set_stage_raises_if_invalid(self):
+        with self.assertRaises(ValueError):
+            self.episode.set_stage('Whoops', self.user, {})
+
+    def test_update_from_dict_raises_if_invalid_stage(self):
+        data = dict(
+            stage='Whoops',
+            id=self.episode.id
+        )
+        with self.assertRaises(ValueError):
+            self.episode.update_from_dict(data, self.user)
 
     def test_can_set_tag_names(self):
         test_cases = [
@@ -118,7 +138,7 @@ class EpisodeTest(OpalTestCase):
         for field in expected:
             self.assertIn(field, as_dict)
 
-        self.assertEqual(as_dict["stage"], "Active TB")
+        self.assertEqual(as_dict["stage"], "Inpatient")
 
     def test_get_field_names_to_extract(self):
         # field names to extract should be the same


### PR DESCRIPTION
Adds enforced stages to EpisodeCategory objects, as well as changing the Episode - Category lookup mechanism.

I think this should effectively close the following tickets:

#671 Document what an episode is
#1358 documentation for episode categories tweaks
#949 category name .lower() slug look up
#669 Episode stages 
