### PR TITLE
De obfuscate pathway errors

### DIFF
--- a/opal/core/exceptions.py
+++ b/opal/core/exceptions.py
@@ -33,3 +33,7 @@ class UnexpectedFieldNameError(Error):
 
 class InitializationError(Error):
     pass
+
+
+class MissingTemplateError(Error):
+    pass

--- a/opal/core/pathway/steps.py
+++ b/opal/core/pathway/steps.py
@@ -5,7 +5,6 @@ from functools import wraps
 
 from opal.utils import camelcase_to_underscore
 from opal.core import exceptions
-from opal.core.exceptions import InitializationError
 
 
 def delete_others(data, model, patient=None, episode=None):
@@ -102,21 +101,27 @@ class Step(object):
                         'A step needs either a display_name'
                         ' or a model'
                     )
-                    raise InitializationError(er)
+                    raise exceptions.InitializationError(er)
             if not getattr(self, "template", None):
                 if "template" not in kwargs:
                     er = (
                         'A step needs either a template'
                         ' or a model'
                     )
-                    raise InitializationError(er)
+                    raise exceptions.InitializationError(er)
 
     @extract_pathway_field
     def get_template(self):
         if self.multiple:
-            return self.multiple_template
+            t =  self.multiple_template
         else:
-            return self.model.get_form_template()
+            t = self.model.get_form_template()
+        if t is None:
+            msg = "Unable to locate form template for subrecord: {0}".format(
+                self.model.get_display_name()
+            )
+            raise exceptions.MissingTemplateError(msg)
+        return t
 
     @extract_pathway_field
     def get_display_name(self):

--- a/opal/core/pathway/tests/test_steps.py
+++ b/opal/core/pathway/tests/test_steps.py
@@ -1,16 +1,21 @@
-from opal.core.test import OpalTestCase
+"""
+unittests for opal.core.pathway.steps
+"""
 from django.core.urlresolvers import reverse
+from mock import MagicMock
+
+from opal.core import exceptions
+from opal.core.test import OpalTestCase
 from opal.tests import models as test_models
 
 from opal.core.pathway import Step, HelpTextStep, PagePathway
-from opal.core.pathway.steps import InitializationError
 from opal.core.pathway.tests.pathway_test.pathways import SomeComplicatedStep
 
 
 class StepTestCase(OpalTestCase):
 
     def test_step_cant_be_multiple_without_a_model(self):
-        with self.assertRaises(InitializationError):
+        with self.assertRaises(exceptions.InitializationError):
             Step(multiple=True)
 
     def test_to_dict_model_passed_in(self):
@@ -89,7 +94,7 @@ class StepTestCase(OpalTestCase):
         )
 
     def test_no_display_name(self):
-        with self.assertRaises(InitializationError) as er:
+        with self.assertRaises(exceptions.InitializationError) as er:
             Step(
                 template="some_template.html"
             )
@@ -98,13 +103,20 @@ class StepTestCase(OpalTestCase):
         )
 
     def test_no_template(self):
-        with self.assertRaises(InitializationError) as er:
+        with self.assertRaises(exceptions.InitializationError) as er:
             Step(
                 display_name="no template"
             )
         self.assertEqual(
             str(er.exception), "A step needs either a template or a model"
         )
+
+    def test_model_has_no_form_template(self):
+        mock_model = MagicMock(name='Model')
+        mock_model.get_form_template.return_value = None
+        step = Step(model=mock_model)
+        with self.assertRaises(exceptions.MissingTemplateError):
+            step.get_template()
 
 
 class HelpTextStepTestCase(OpalTestCase):


### PR DESCRIPTION
Currently the pathway templates assume that `Step.get_template` can't return `None` as they directly include it.

If it _does_ return `None (perhaps because perhaps you've forgotten to create the form template), then the error you get in the browser is not particularly illuminating and somewhat unhelpfully points at the _parent_ pathway template include at:
```
  {% for step in pathway.get_steps %}
    {% include step.get_base_template %}
  {% endfor %}
```

Given that we know what the issue is and can raise an appropriate error message quite easily, do that.