### PR TITLE
Urls have changed in Django 1.10

### DIFF
--- a/opal/scaffolding/plugin_scaffold/app/urls.py.jinja2
+++ b/opal/scaffolding/plugin_scaffold/app/urls.py.jinja2
@@ -6,6 +6,5 @@ from django.conf.urls import url
 from {{ name }} import views
 
 urlpatterns = [
-    '',
     #url(pattern, view)
 ]


### PR DESCRIPTION
Not doing this results in the error:

ERRORS:
?: (urls.E004) Your URL pattern '' is invalid. Ensure that urlpatterns is a list of url() instances.
	HINT: Try removing the string ''. The list of urlpatterns should not have a prefix string as the first element.