### PR TITLE
Uplift requests dependency to 2.18.4 and update all references in project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ in `opal.core.views.
 * Psycopg2: 2.5 -> 2.7
 * Jinja2: 2.9.6 -> 2.10
 * Ffs: 0.0.8.1 -> 0.0.8.2
+* Requests: 2.7.0 -> 2.18.4
 
 #### Testing options
 

--- a/doc/docs/reference/upgrading.md
+++ b/doc/docs/reference/upgrading.md
@@ -21,6 +21,7 @@ you have specified them in for instance, a requirements.txt.
     psycopg==2.7
     ffs==0.0.8.2
     opal==0.10.0
+    requests==2.18.4
 
 
 After re-installing (via for instance `pip install -r requirements.txt`) you will

--- a/opal/scaffolding/scaffold/requirements.txt.jinja2
+++ b/opal/scaffolding/scaffold/requirements.txt.jinja2
@@ -10,7 +10,7 @@ django-reversion==1.10.2
 django-axes==1.4.0
 ffs==0.0.8.2
 letter==0.4.1
-requests==2.7.0
+requests==2.18.4
 djangorestframework==3.4.7
 django-compressor==1.5
 python-dateutil==2.4.2

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'ffs>=0.0.8.2',
         'letter==0.4.1',
         'jinja2==2.10',
-        'requests==2.7.0',
+        'requests==2.18.4',
         'django==1.10.8',
         'django-reversion==1.10.2',
         'django-axes==1.7.0',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ coveralls
 celery==3.1.19
 django-celery==3.1.17
 flake8==3.2.1
+requests==2.18.4


### PR DESCRIPTION
- Updates the setup.py dependency for `requests` to 2.18.4
- Adds `requests` as a pinned dependency in test-requirements.txt

Change history https://github.com/requests/requests/blob/v2.18.4/HISTORY.rst

This closes #1398 with 'Option 2'