### PR TITLE
127.0.0.1 should be in ALLOWED_HOSTS

### DIFF
--- a/opal/scaffolding/scaffold/app/settings.py.jinja2
+++ b/opal/scaffolding/scaffold/app/settings.py.jinja2
@@ -34,6 +34,7 @@ except ImportError:
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = [
     'localhost',
+    '127.0.0.1',
     '.herokuapp.com'
 ]
 


### PR DESCRIPTION
I'm not quite sure why, but on my system (Linux), `localhost` as a string is not seemingly treated as equivalent to `127.0.0.1` in terms of Django's ALLOWED_HOSTS setting. This results in a DisallowedHost Exception every time I start a new Opal app.

The fix is simple, but I have to change it in every new Opal app I create. It would be nice if it was already in the scaffolding of `settings.py`, unless there's a good reason not to (such as there being some easier way to achieve the same ends which I'm not aware of, or if it introduces a security risk)

I've run the tests locally and everything passes OK