### PR TITLE
amended regex to allow matching of templates with numerics in them

### DIFF
--- a/opal/core/pathway/urls.py
+++ b/opal/core/pathway/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 
 from opal.core.pathway import views, api
 
-PATHWAY_REGEX = "(?P<name>[a-z_]+)"
+PATHWAY_REGEX = "(?P<name>[0-9a-z_]+)"
 PATIENT_ID_REGEX = "(?P<patient_id>[0-9]+)"
 EPISODE_ID_REGEX = "(?P<episode_id>[0-9]+)"
 


### PR DESCRIPTION
Hi @fredkingham 

Earlier today @davidmiller fixed [this issue](https://github.com/openhealthcare/opal/pull/1421 with template lookups where the model name included a numeric, eg `class Fp17DentalCareProvider(models.PatientSubrecord):`

He asked if I would do the same to allow Pathway lookups to also work.

I've amended the `PATHWAY_REGEX`, which was straightforward. What I've struggled with is making a TestCase that tests this as I could not work out what the parameters for `reverse()` should be in this case. I'd looked at what @davidmiller had done and have also looked at various parts of the Opal source eg `class PathwayTemplateView` but got no further.

This PR includes just the regex fix, with no test. I'm happy to supply a test if you can point me in the right direction.