### PR TITLE
When you add fields to a multi select, allow the text box to expand

### DIFF
--- a/opal/static/css/opal.css
+++ b/opal/static/css/opal.css
@@ -1125,3 +1125,13 @@ hr.bold{
 .text-avatar{
     height: 20px;
 }
+
+.form-group .ui-select-container.ui-select-multiple {
+    height: auto;
+}
+
+.select2-choices {
+  min-height: 150px;
+  max-height: 150px;
+  overflow-y: auto;
+}


### PR DESCRIPTION
As you add elements to a multi select, we expand accordingly...

<img width="771" alt="screen shot 2018-03-02 at 12 54 42" src="https://user-images.githubusercontent.com/2175455/36899891-059a5b8e-1e19-11e8-9fa7-a58d119f0653.png">
<img width="695" alt="screen shot 2018-03-02 at 12 54 54" src="https://user-images.githubusercontent.com/2175455/36899894-07a3e670-1e19-11e8-9f67-bf95f0770e7a.png">
<img width="715" alt="screen shot 2018-03-02 at 12 55 04" src="https://user-images.githubusercontent.com/2175455/36899896-096c6450-1e19-11e8-94c5-57f9542b186b.png">




