### PR TITLE
undefineds are not serialised, so we explicitly set start end to null

### DIFF
--- a/opal/static/js/opal/services/episode.js
+++ b/opal/static/js/opal/services/episode.js
@@ -155,11 +155,23 @@ angular.module('opal.services')
 
             makeCopy: function(){
                 var start, end;
+                /*
+                * undefined is not serailised.
+                * we explicitly set to null, to set
+                * fields that were populated to null
+                */
                 if(this.start){
                   start = moment(this.start).toDate();
                 }
+                else if("start" in this){
+                  start = null;
+                }
+
                 if(this.end){
                   end = moment(this.end).toDate();
+                }
+                else if("end" in this){
+                  end = null;
                 }
                 var copy = {
                     id               : this.id,

--- a/opal/static/js/opal/services/episode.js
+++ b/opal/static/js/opal/services/episode.js
@@ -163,14 +163,14 @@ angular.module('opal.services')
                 if(this.start){
                   start = moment(this.start).toDate();
                 }
-                else if("start" in this){
+                else{
                   start = null;
                 }
 
                 if(this.end){
                   end = moment(this.end).toDate();
                 }
-                else if("end" in this){
+                else{
                   end = null;
                 }
                 var copy = {

--- a/opal/static/js/test/episode.service.test.js
+++ b/opal/static/js/test/episode.service.test.js
@@ -33,6 +33,7 @@ describe('Episode', function() {
             expect(moment(newEpisode.start).format('DD/MM/YYYY')).toEqual("19/11/2013");
             expect(moment(newEpisode.end).format('DD/MM/YYYY')).toEqual("25/05/2016");
         });
+
     });
 
     describe('compare', function(){
@@ -274,8 +275,8 @@ describe('Episode', function() {
       expect(copy.id).toBe(123);
       expect(copy.category_name).toBe('Inpatient');
       expect(copy.consistency_token).toBe(undefined);
-      expect(copy.start).toEqual(undefined);
-      expect(copy.end).toEqual(undefined);
+      expect(copy.start).toEqual(null);
+      expect(copy.end).toEqual(null);
     });
 
     describe('communicating with server', function (){

--- a/opal/static/js/test/episode.service.test.js
+++ b/opal/static/js/test/episode.service.test.js
@@ -269,9 +269,9 @@ describe('Episode', function() {
     });
 
     it('start and end should be null if not set', function(){
+      episode.start = undefined;
+      episode.end = undefined;
       var copy = episode.makeCopy();
-      delete copy.start;
-      delete copy.end;
       expect(copy.id).toBe(123);
       expect(copy.category_name).toBe('Inpatient');
       expect(copy.consistency_token).toBe(undefined);


### PR DESCRIPTION
fixes openhealthcare/elcid#1545 

Undischarge date of discharge was not being set because we were setting end to `undefined` rather than `null`.

 `undefined` is not serialised to json, we weren't removing it when it hit the server. 