### PR TITLE
typo 'clinicial' => 'clinical' and a little formatting tweak

### DIFF
--- a/doc/docs/guides/json_api.md
+++ b/doc/docs/guides/json_api.md
@@ -14,15 +14,17 @@ You may examine the API of any running Opal application by navigating to the url
 You can add your own APIs to the Opal API namespace [from plugins](plugins.md#adding-apis) or
 by registering them directly with the router.
 
-    from rest_framework.viewsets import ViewSet
-    from rest_framework.response import Response
-    from opal.core.api import router
+```python
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from opal.core.api import router
 
 
-    class PingViewSet(ViewSet):
-        def list(self, request): return Response('pong')
+class PingViewSet(ViewSet):
+    def list(self, request): return Response('pong')
 
-    router.register('ping', PingViewSet)
+router.register('ping', PingViewSet)
+```
 
 APIs can make use of method decorators `item_from_pk`, `episode_from_pk` and `patient_from_pk` that will replace a pk passed into a method with self.model, Episode or Patient respectively.
 
@@ -30,12 +32,11 @@ e.g.
 
 ```python
 class SomeBespokeViewset(viewsets.Viewset):
-  model = ClinicialInformation
+  model = ClinicalInformation
 
   @item_from_pk
   def some_api_endpoint(self, request, clinical_information):
     # Some logic
-
 ```
 
 ### Authentication
@@ -66,7 +67,7 @@ Session based authentication enables users logged in via the standard Django aut
 to use the API. This is what most Opal applications in the browser will use.
 
 #### Token Based
-Token based authentication is targetted at other applications consuming the Opal API, and
+Token based authentication is targeted at other applications consuming the Opal API, and
 requires the application to pass an API token as a header. These tokens must be associated
 with a Django user, and can be created in the Django Admin.
 


### PR DESCRIPTION
converted indented code block to a ``` style block
clinicial => clinical
removed unused whitespace
targetted => targeted