### PR TITLE
fix to default tests.py in the Opal scaffold

### DIFF
--- a/opal/scaffolding/scaffold/app/tests.py.jinja2
+++ b/opal/scaffolding/scaffold/app/tests.py.jinja2
@@ -7,8 +7,8 @@ from {{ name }} import models, patient_lists
 
 class WeHaveSomeModelsTestCase(OpalTestCase):
     def test_there_is_a_model(self):
-        demographics = models.Demographics(name='Larry')
-        self.assertEqual('Larry', demographics.name)
+        demographics = models.Demographics(first_name='Larry')
+        self.assertEqual('Larry', demographics.first_name)
 
 class PatientListTestCase(OpalTestCase):
     def test_queryset(self):


### PR DESCRIPTION
changed `name` to `first_name` as per change to models https://github.com/openhealthcare/opal/commit/b318d4954f18ba60677b99dc2bdc6e6aaac25c1c