### PR TITLE
Attempt to redirect the user to where they wanted to go on CSRF failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ library.
 
 Adds a setting `OPAL_FAVICON_PATH` to specify the application Favicon to use.
 
+Configures the setting `CSRF_FAILURE_VIEW` to use the bundled `opal.views.csrf_failure` view.
+
 ### 0.9.1 (Minor Release)
 
 #### Pathways ContextProcessor

--- a/doc/docs/reference/upgrading.md
+++ b/doc/docs/reference/upgrading.md
@@ -91,6 +91,16 @@ Django now ships with `django.contrib.auth.mixins.LoginRequiredMixin`. According
 removed `opal.core.views.LoginRequiredMixin`. A direct switch to the Django class should
 work seamlessly without any functional differences.
 
+##### CSRF_FAILURE_VIEW
+We now ship the `opal.views.csrf_failure` view which can be enabled by adding
+`CSRF_FAILURE_VIEW = 'opal.views.csrf_failure'` in your settings.py. This will
+redirect a user to their intended destination on a CSRF failure. This mitigates
+an edge case where an unauthenticated user opens two pages at the same time.
+Both pages will get redirected to the login form and whichever page the user
+logs into second will throw a CSRF failure because Django invalidates CSRF
+tokens on login.
+
+
 ### 0.9.0 -> 0.9.1
 
 #### Upgrading Opal

--- a/opal/scaffolding/scaffold/app/settings.py.jinja2
+++ b/opal/scaffolding/scaffold/app/settings.py.jinja2
@@ -192,6 +192,7 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 # CSRF
 # https://docs.djangoproject.com/en/1.10/ref/settings/#csrf-cookie-name
 CSRF_COOKIE_NAME = 'XSRF-TOKEN'
+CSRF_FAILURE_VIEW = 'opal.views.csrf_failure'
 
 
 # ========== THIRD PARTY ==========

--- a/opal/views.py
+++ b/opal/views.py
@@ -4,7 +4,7 @@ Module entrypoint for core Opal views
 from django.core.urlresolvers import reverse
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import login
-from django.http import HttpResponseNotFound
+from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import get_template
 from django.template import TemplateDoesNotExist
@@ -295,3 +295,11 @@ class RawTemplateView(LoginRequiredMixin, TemplateView):
         except TemplateDoesNotExist:
             return HttpResponseNotFound()
         return super(RawTemplateView, self).get(*args, **kw)
+
+
+def csrf_failure(request, reason):
+    if request.POST:
+        next_url = request.POST.get('next', '/')
+        return redirect(next_url)
+
+    return HttpResponseForbidden

--- a/opal/views.py
+++ b/opal/views.py
@@ -299,7 +299,7 @@ class RawTemplateView(LoginRequiredMixin, TemplateView):
 
 def csrf_failure(request, reason):
     if request.POST:
-        next_url = request.POST.get('next', '/')
+        next_url = request.GET.get('next', '/')
         return redirect(next_url)
 
     return HttpResponseForbidden


### PR DESCRIPTION
This addresses the case where an unauthenticated user ends up with two
browser windows/tabs pointing at the login form.  Both versions of the
page will have valid CSRF tokens in their forms.  The user then logs in
with one of those pages and Django cycles the CSRF token, making the
second page's token invalid.  The user then tries to log in via the
second page and gets a CSRF failure/403.

This change redirects the user to their intended page via the `next`
param (falling back to /).  An unauthenticated user should be redirected
to the login page again (getting a valid CSRF token).

Fixes #596 