### PR TITLE
in elcid there is a change that changes mine to be a tagged list, thi…

### DIFF
--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -330,12 +330,6 @@ class TaggedPatientListMetadata(metadata.Metadata):
             if tag and hasattr(tagging, 'subtag'):
                 data["tags"][tag]["parent_tag"] = tagging.tag
 
-        data["tags"]["mine"] = dict(
-            name="mine",
-            display_name="Mine",
-            slug="mine",
-            direct_add=True,
-        )
         return data
 
 

--- a/opal/core/search/queries.py
+++ b/opal/core/search/queries.py
@@ -378,10 +378,19 @@ class DatabaseQuery(QueryBackend):
             kw = {queryset_path: query['query']}
 
             if Mod == models.Tagging:
-                tag_name = query['field'].replace(" ", "_").title()
-                eps = models.Episode.objects.filter(
-                    tagging__value__iexact=tag_name
-                )
+                if query['field'] == "mine":
+                    tags = models.Tagging.objects.filter(
+                        value="mine",
+                        user=self.user
+                    )
+                    eps = models.Episode.objects.filter(
+                        tagging__in=tags
+                    )
+                else:
+                    tag_name = query['field'].replace(" ", "_").title()
+                    eps = models.Episode.objects.filter(
+                        tagging__value__iexact=tag_name
+                    )
 
             elif issubclass(Mod, models.EpisodeSubrecord):
                 eps = models.Episode.objects.filter(**kw)


### PR DESCRIPTION
…s removes it from the metadata and adds in an explicit case in search. We will remove this when we remove to search 2.0

I'm afraid at the moment its not obvious how to do with this search rules as tagging is already a bit awkward. In Search 2.0 tagging is change to be a bit more traditional. As a field from episode. So hopefully we can remove it there.

Fixes openhealthcare/elcid#1553
Related to https://github.com/openhealthcare/elcid/pull/1567