### PR TITLE
change hyphenated slug in the Tutorial to use an underscore

### DIFF
--- a/doc/docs/tutorials/pathway_tutorial.md
+++ b/doc/docs/tutorials/pathway_tutorial.md
@@ -25,7 +25,7 @@ from opal.core import pathway
 
 class MyPathway(pathway.PagePathway):
     display_name = 'My Awesome Pathway'
-    slug         = 'awesomest-pathway'
+    slug         = 'awesomest_pathway'
 ```
 
 ### Taking Our First Steps


### PR DESCRIPTION
because hyphens do not work in `slug`

https://github.com/openhealthcare/opal/blob/v0.10.0/opal/core/pathway/urls.py#L8

If you use a hyphen you get a template not found error from Angular