### PR TITLE
Pathway slug hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ Adds the `rows` option to the textarea template tag which just fills in the html
 
 Configures the setting `CSRF_FAILURE_VIEW` to use the bundled `opal.views.csrf_failure` view.
 
+Pathway slugs may now include hyphens as well as numbers, lower case letters and underscores.
+
 
 ### 0.9.1 (Minor Release)
 

--- a/opal/core/pathway/tests/test_pathways.py
+++ b/opal/core/pathway/tests/test_pathways.py
@@ -22,7 +22,7 @@ from opal.core.pathway import pathways, Pathway, WizardPathway
 
 class PathwayExample(pathways.Pathway):
     display_name = "Dog Owner"
-    slug = 'dog_owner'
+    slug = 'dog-owner'
     icon = "fa fa-something"
     template_url = "/somewhere"
 
@@ -153,7 +153,7 @@ class TestSavePathway(PathwayTestCase):
 
     def setUp(self):
         self.url = reverse(
-            "pathway", kwargs=dict(name="dog_owner")
+            "pathway", kwargs=dict(name="dog-owner")
         )
         super(TestSavePathway, self).setUp()
 
@@ -433,13 +433,16 @@ class TestPathwayMethods(OpalTestCase):
     def test_slug(self):
         self.assertEqual('colourpathway', ColourPathway().slug)
 
+    def test_get_by_hyphenated_slug(self):
+        self.assertEqual(PathwayExample, Pathway.get('dog-owner'))
+
     def test_vanilla_to_dict(self):
         as_dict = PathwayExample().to_dict(is_modal=False)
         self.assertEqual(len(as_dict["steps"]), 2)
         self.assertEqual(as_dict["display_name"], "Dog Owner")
         self.assertEqual(as_dict["icon"], "fa fa-something")
         self.assertEqual(as_dict["save_url"], reverse(
-            "pathway", kwargs=dict(name="dog_owner")
+            "pathway", kwargs=dict(name="dog-owner")
         ))
         self.assertEqual(as_dict["pathway_service"], "Pathway")
         self.assertEqual(as_dict["finish_button_text"], "Save")

--- a/opal/core/pathway/tests/test_url.py
+++ b/opal/core/pathway/tests/test_url.py
@@ -9,3 +9,9 @@ class PathwayReverseUrlTests(OpalTestCase):
             '/pathway/templates/numerical10.html',
             reverse('pathway_template', kwargs={'name': 'numerical10'})
         )
+
+    def test_reverse_pathway_url_with_hyphens(self):
+        self.assertEqual(
+            '/pathway/templates/o-m-g.html',
+            reverse('pathway_template', kwargs={'name': 'o-m-g'})
+        )

--- a/opal/core/pathway/urls.py
+++ b/opal/core/pathway/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 
 from opal.core.pathway import views, api
 
-PATHWAY_REGEX = "(?P<name>[0-9a-z_]+)"
+PATHWAY_REGEX = "(?P<name>[0-9a-z_\-]+)"
 PATIENT_ID_REGEX = "(?P<patient_id>[0-9]+)"
 EPISODE_ID_REGEX = "(?P<episode_id>[0-9]+)"
 


### PR DESCRIPTION
I can't think of a good reason we don't allow pathway slugs to include `-` characters ? 