### PR TITLE
1443 can we stop double clicks in the spread sheet view

### DIFF
--- a/opal/static/js/opal/services/record_editor.js
+++ b/opal/static/js/opal/services/record_editor.js
@@ -47,7 +47,11 @@ angular.module('opal.services').factory('RecordEditor', function(
       }
     };
 
+
     self.openEditItemModal = function(item, name){
+
+      console.log("modal" + Date.now() );
+
       $rootScope.state = 'modal';
       var template_url = '/templates/modals/' + name + '.html/';
 
@@ -75,6 +79,8 @@ angular.module('opal.services').factory('RecordEditor', function(
               }
           };
 
+
+
           var modal = $modal.open(modal_opts);
 
           modal.result.then(function(result) {
@@ -87,9 +93,14 @@ angular.module('opal.services').factory('RecordEditor', function(
       return deferred.promise;
     };
 
+    // _debounce() prevents multiple modals opening on accidental double click
+    var debounceTime = 200 // milliseconds
+    self.debouncedOpenEditItemModal = _.debounce(self.openEditItemModal, debounceTime, true);
+
     self.editItem = function(name, iix){
       var item = self.getItem(name, iix);
-      return self.openEditItemModal(item, name);
+      console.log("click" + Date.now() )
+      return self.debouncedOpenEditItemModal(item, name);
     };
 
     self.newItem = function(name){
@@ -101,7 +112,7 @@ angular.module('opal.services').factory('RecordEditor', function(
         deferred.resolve();
         return deferred.promise;
       }
-      return self.openEditItemModal(item, name);
+      return self.debouncedOpenEditItemModal(item, name);
     };
   };
 

--- a/opal/static/js/opal/services/record_editor.js
+++ b/opal/static/js/opal/services/record_editor.js
@@ -50,8 +50,6 @@ angular.module('opal.services').factory('RecordEditor', function(
 
     self.openEditItemModal = function(item, name){
 
-      console.log("modal" + Date.now() );
-
       $rootScope.state = 'modal';
       var template_url = '/templates/modals/' + name + '.html/';
 
@@ -99,7 +97,6 @@ angular.module('opal.services').factory('RecordEditor', function(
 
     self.editItem = function(name, iix){
       var item = self.getItem(name, iix);
-      console.log("click" + Date.now() )
       return self.debouncedOpenEditItemModal(item, name);
     };
 


### PR DESCRIPTION
Adds an underscore.js `debounce` wrapper around `self.openEditItemModal` returning `self.debouncedOpenEditItemModal`.

Calls to this function are debounced so they can only be triggered once in each debounceTime (I've set to 200ms for now). The last parameter `true` is the 'immediate' flag to tell underscore to trigger on the _leading edge_ of the event (trigger **then** lockout for 200ms), as opposed to triggering at the end of the 200ms (lockout for 200ms **then** trigger).

I've tested this in elcid-uch both manually (trying to double click and trigger two modals) and also by putting two sequential calls to `self.openEditItemModal` in the `self.editItem` function.

With two sequential calls to `self.openEditItemModal`, two modals open.
With two sequential calls to `self.debouncedOpenEditItemModal`, only one modal opens.

opal branch for testing: 1443-can-we-stop-double-clicks-in-the-spread-sheet-view

closes openhealthcare/elcid#1443



