### PR TITLE
As menuitem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ for a method named `get_$attr` and will call that if it exists.
 Adds the method `.get_absolute_url()` to `opal.core.pathways.Pathway` and
 `opal.core.patient_lists.PatientList`.
 
+Adds the Opal error `SignatureError`.
 
 ### 0.9.1 (Minor Release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,9 @@ we run `python manage.py scaffold {my_app_name}`
 
 #### as_menuitem helpers
 
-Applications using Opal Menuitems often wish to add menu items for Patient Lists.
+Applications using Opal Menuitems often wish to add menu items for Patient Lists and
+Pathways.
+
 To aid this, the `.as_menuitem()` method now creates one from the target class with
 sensible but overridable defaults.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,8 @@ Configures the setting `CSRF_FAILURE_VIEW` to use the bundled `opal.views.csrf_f
 Adds the utility function `opal.utils.get`. Similar to the `getattr` builtin, `get` looks
 for a method named `get_$attr` and will call that if it exists.
 
-Adds the method `.get_absolute_url()` to `opal.core.Pathway`.
+Adds the method `.get_absolute_url()` to `opal.core.pathways.Pathway` and
+`opal.core.patient_lists.PatientList`.
 
 
 ### 0.9.1 (Minor Release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,9 +105,13 @@ library.
 
 Adds a setting `OPAL_FAVICON_PATH` to specify the application Favicon to use.
 
-Adds the `rows` option to the textarea template tag which just fills in the html textarea `rows` attribute. Text areas are defaulted to 5 rows (the same as before).
+Adds the `rows` option to the textarea template tag which just fills in the html textarea
+`rows` attribute. Text areas are defaulted to 5 rows (the same as before).
 
 Configures the setting `CSRF_FAILURE_VIEW` to use the bundled `opal.views.csrf_failure` view.
+
+Adds the utility function `opal.utils.get`. Similar to the `getattr` builtin, `get` looks
+for a method named `get_$attr` and will call that if it exists.
 
 
 ### 0.9.1 (Minor Release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,18 +68,6 @@ We remove a number of stale unused templates:
 As Django ships with a `LoginRequiredMixin` of its own we no longer roll our own
 in `opal.core.views.
 
-#### Updates to the Dependency Graph
-
-* Django: 1.8.13 -> 1.10.8
-* Django Reversion: 1.8.7 -> 1.10.2
-* Django Rest Framework: 3.2.2 -> 3.4.7
-* Psycopg2: 2.5 -> 2.7
-* Jinja2: 2.9.6 -> 2.10
-* Ffs: 0.0.8.1 -> 0.0.8.2
-* Requests: 2.7.0 -> 2.18.4
-* django-celery: 3.1.17 -> 3.2.2
-* celery: 3.1.19 -> 3.1.25
-
 #### Testing options
 
 Adds a `--failfast` option to the test harness to stop test runs on the first
@@ -91,12 +79,28 @@ manually add support for `--failfast` passthrough to your `runtests.py`.
 If you are a plugin developer upgrading an existing plugin you will have to
 manually add support for `--failfast` passthrough to your `runtests.py`.
 
-
 #### Moves scaffold to be a django management command
 
 The rest of the api is still the same but now
 we run `python manage.py scaffold {my_app_name}`
 
+#### as_menuitem helpers
+
+Applications using Opal Menuitems often wish to add menu items for Patient Lists.
+To aid this, the `.as_menuitem()` method now creates one from the target class with
+sensible but overridable defaults.
+
+#### Updates to the Dependency Graph
+
+* Django: 1.8.13 -> 1.10.8
+* Django Reversion: 1.8.7 -> 1.10.2
+* Django Rest Framework: 3.2.2 -> 3.4.7
+* Psycopg2: 2.5 -> 2.7
+* Jinja2: 2.9.6 -> 2.10
+* Ffs: 0.0.8.1 -> 0.0.8.2
+* Requests: 2.7.0 -> 2.18.4
+* django-celery: 3.1.17 -> 3.2.2
+* celery: 3.1.19 -> 3.1.25
 
 #### Misc Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ Configures the setting `CSRF_FAILURE_VIEW` to use the bundled `opal.views.csrf_f
 Adds the utility function `opal.utils.get`. Similar to the `getattr` builtin, `get` looks
 for a method named `get_$attr` and will call that if it exists.
 
+Adds the method `.get_absolute_url()` to `opal.core.Pathway`.
+
 
 ### 0.9.1 (Minor Release)
 

--- a/doc/docs/reference/pathways.md
+++ b/doc/docs/reference/pathways.md
@@ -39,6 +39,10 @@ If set, this template will be used if your pathway is opened in a modal. If its 
 
 ### Class Methods
 
+#### `Pathway.as_menuitem(href=None, activepattern=None, icon=None, display=None)`
+
+Return an instance of `opal.core.menus.MenuItem` that will direct the user to this pathway.
+
 #### `Pathway.get_slug()`
 
 Returns a string which should be used as the slug for this Pathway.

--- a/doc/docs/reference/pathways.md
+++ b/doc/docs/reference/pathways.md
@@ -39,6 +39,15 @@ If set, this template will be used if your pathway is opened in a modal. If its 
 
 ### Methods
 
+#### `Pathway.get_slug()`
+
+Returns a string which should be used as the slug for this Pathway.
+
+```
+MyPathwy.get_slug()
+"mypathway"
+```
+
 #### `Pathway.redirect_url(self, patient, episde)`
 
 Returns a string that we should redirect to on success. Defaults to
@@ -64,7 +73,7 @@ Steps are a single section within a form, and can be instances of either `opal.m
 `pathway.Step` subclasses. You can use both types of Step in a given Pathway.
 
 More detail on Steps is given in the [Guides section on Pathways](../guides/pathways.md)
-        
+
 ## HelpTextStep
 
 A Step subclass with help text to the side of the form

--- a/doc/docs/reference/pathways.md
+++ b/doc/docs/reference/pathways.md
@@ -37,16 +37,27 @@ The name of the pathway template, it must include a div/span with the class .to_
 
 If set, this template will be used if your pathway is opened in a modal. If its not set the template attribute will be used.
 
-### Methods
+### Class Methods
 
 #### `Pathway.get_slug()`
 
 Returns a string which should be used as the slug for this Pathway.
 
-```
+```python
 MyPathwy.get_slug()
 "mypathway"
 ```
+
+#### `Pathway.get_absolute_url()`
+
+Returns a string which is the absolute URL of this Pathway.
+
+```python
+MyPathway.get_absolute_url()
+"/pathway/#/mypathway/"
+```
+
+### Methods
 
 #### `Pathway.redirect_url(self, patient, episde)`
 

--- a/doc/docs/reference/patient_list.md
+++ b/doc/docs/reference/patient_list.md
@@ -38,16 +38,21 @@ Returns a string which is the absolute URL of this list.
 MyList.get_absolute_url()
 "/#/list/my_list"
 ```
+#### `PatientList.as_menuitem(href=None, activepattern=None, icon=None, display=None)`
+
+Return an instance of `opal.core.menus.MenuItem` that will direct the user to this
+patient list.
 
 ## TaggedPatientList
 
-Tagged Patient Lists inherit from Patient Lists - as such they have all of the same methods and properties
-of Patient Lists.
+Tagged Patient Lists inherit from Patient Lists - as such they have all of the same methods and
+properties of Patient Lists.
 
 ## Card Patient List Template
 Change your patientlist template_name to "patient_lists/card_list.html".
 
-This will display the patient list as a series of 'cards', more analagous to a twitter stream than a spreadsheet like the default list.
+This will display the patient list as a series of 'cards', more analagous to a twitter stream
+than a spreadsheet like the default list.
 
 ## Table Patient list Template
 Change your patientlist template_name to "patient_lists/card_list.html".

--- a/doc/docs/reference/patient_list.md
+++ b/doc/docs/reference/patient_list.md
@@ -16,7 +16,6 @@ How we want to refer to this list on screen to users.
 
 A custom comparator service to set sort order within a list. Defaults to None.
 
-
 #### PatientList.allow_add_patient
 
 Whether we should show the add patient button.
@@ -28,6 +27,17 @@ Defaults to `True`.
 Whether we should allow the user to edit teams.
 
 Defaults to `True`
+
+### Classmethods
+
+#### `PatientList.get_absolute_url()`
+
+Returns a string which is the absolute URL of this list.
+
+```python
+MyList.get_absolute_url()
+"/#/list/my_list"
+```
 
 ## TaggedPatientList
 

--- a/doc/docs/reference/reference_guides.md
+++ b/doc/docs/reference/reference_guides.md
@@ -46,6 +46,7 @@ The following reference guides are available:
 [The panels Templatetag library](panels_templatetags.md) | Rendering record panels
 [The menus Templatetag library](menus_templatetags.md) | Rendering application menus
 [Javascript Helpers](javascript/javascript_helpers.md)| Angular directives, filters and $rootScope methods
+[Utils module](utils.md)| The `opal.utils` module - miscellaneous helpful python utilities
 
 ### Opal core modules
 

--- a/doc/docs/reference/utils.md
+++ b/doc/docs/reference/utils.md
@@ -24,3 +24,30 @@ test runs.
 >>> write('hai')
 hai
 ```
+
+## get( object, attribute, default=None )
+
+Similar to the `getattr` builtin, `get` will fetch an attribute of on object.
+
+If there is a `get_` method defined, `get` will use that in preference to
+direct object accesss.
+
+If there is no `get_` method defined and DEFAULT is passed, use
+that as the default option for `getattr()`.
+
+```python
+class PoliteConversation(object):
+
+    formal_greeting = 'Hello'
+
+    @classmethod
+    def get_greeting(klass):
+        return 'Hi'
+
+
+get(PoliteConversation, 'formal_greeting')
+"Hello"
+
+get(PoliteConversation, 'greeting')
+"Hi"
+```

--- a/doc/docs/reference/utils.md
+++ b/doc/docs/reference/utils.md
@@ -1,0 +1,26 @@
+# opal.utils
+
+The `opal.utils` module contains a number of helpful python utilities.
+
+## find_template( template_list )
+
+Given an iterable of template paths, return the first one that
+exists on our template path or None.
+
+```python
+find_template(['not_a_real_template.html'])
+None
+```
+
+## write( what )
+
+Writes the argument to `sys.stdout` unless it detects an active test run.
+If run during tests, it should do nothing.
+
+Used by Opal for chatty commandline utilities that should be quieter during
+test runs.
+
+```python
+>>> write('hai')
+hai
+```

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -90,6 +90,7 @@ pages:
       - Panel Template tags: reference/panels_templatetags.md
       - Menu Template tag: reference/menus_templatetags.md
       - Javascript helpers: reference/javascript/javascript_helpers.md
+      - Utils module: reference/utils.md
 
       # Search
       - Search Queries: reference/search_queries.md

--- a/opal/core/exceptions.py
+++ b/opal/core/exceptions.py
@@ -37,3 +37,7 @@ class InitializationError(Error):
 
 class MissingTemplateError(Error):
     pass
+
+
+class SignatureError(Error):
+    pass

--- a/opal/core/pathway/pathways.py
+++ b/opal/core/pathway/pathways.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from django.core.urlresolvers import reverse
 from django.db import models, transaction
 from django.utils.text import slugify
+from six import string_types
 
 from opal.core import discoverable, subrecords
 from opal.utils import AbstractBase
@@ -28,6 +29,17 @@ class Pathway(discoverable.DiscoverableFeature):
 
     # any iterable will do, this should be overridden
     steps = []
+
+    @classmethod
+    def get_slug(klass):
+        """
+        Returns a string which should be used as the slug for this pathway
+        """
+        slugattr = getattr(klass, 'slug', None)
+        if slugattr:
+            if isinstance(slugattr, string_types):
+                return slugattr
+        return slugify(klass.__name__)
 
     def get_pathway_service(self, is_modal):
         return self.pathway_service

--- a/opal/core/pathway/pathways.py
+++ b/opal/core/pathway/pathways.py
@@ -41,6 +41,13 @@ class Pathway(discoverable.DiscoverableFeature):
                 return slugattr
         return slugify(klass.__name__)
 
+    @classmethod
+    def get_absolute_url(klass, **kwargs):
+        """
+        Returns a string which is the absolute URL of this Pathway.
+        """
+        return '{0}#/{1}/'.format(reverse('pathway_index'), klass.get_slug())
+
     def get_pathway_service(self, is_modal):
         return self.pathway_service
 

--- a/opal/core/pathway/pathways.py
+++ b/opal/core/pathway/pathways.py
@@ -10,8 +10,8 @@ from django.db import models, transaction
 from django.utils.text import slugify
 from six import string_types
 
-from opal.core import discoverable, subrecords
-from opal.utils import AbstractBase
+from opal.core import discoverable, menus, subrecords
+from opal.utils import AbstractBase, get
 from opal.core.views import OpalSerializer
 from opal.core.pathway import Step
 
@@ -47,6 +47,15 @@ class Pathway(discoverable.DiscoverableFeature):
         Returns a string which is the absolute URL of this Pathway.
         """
         return '{0}#/{1}/'.format(reverse('pathway_index'), klass.get_slug())
+
+    @classmethod
+    def as_menuitem(kls, **kwargs):
+        return menus.MenuItem(
+            href=kwargs.get('href', kls.get_absolute_url()),
+            activepattern=kwargs.get('activepattern', kls.get_absolute_url()),
+            icon=kwargs.get('icon', get(kls, 'icon')),
+            display=kwargs.get('display', get(kls, 'display_name')),
+        )
 
     def get_pathway_service(self, is_modal):
         return self.pathway_service

--- a/opal/core/pathway/tests/test_pathways.py
+++ b/opal/core/pathway/tests/test_pathways.py
@@ -430,6 +430,12 @@ class TestPathwayMethods(OpalTestCase):
     def setUp(self):
         self.patient, self.episode = self.new_patient_and_episode_please()
 
+    def test_get_slug(self):
+        self.assertEqual('colourpathway', ColourPathway.get_slug())
+
+    def test_get_slug_from_attribute(self):
+        self.assertEqual('dog_owner', PathwayExample.get_slug())
+
     def test_slug(self):
         self.assertEqual('colourpathway', ColourPathway().slug)
 

--- a/opal/core/pathway/tests/test_pathways.py
+++ b/opal/core/pathway/tests/test_pathways.py
@@ -444,7 +444,7 @@ class TestPathwayMethods(OpalTestCase):
         self.assertEqual('colourpathway', ColourPathway.get_slug())
 
     def test_get_slug_from_attribute(self):
-        self.assertEqual('dog_owner', PathwayExample.get_slug())
+        self.assertEqual('dog-owner', PathwayExample.get_slug())
 
     def test_get_absolute_url(self):
         self.assertEqual('/pathway/#/colourpathway/', ColourPathway.get_absolute_url())

--- a/opal/core/pathway/tests/test_pathways.py
+++ b/opal/core/pathway/tests/test_pathways.py
@@ -40,6 +40,16 @@ class ColourPathway(Pathway):
         FamousLastWords,
     )
 
+class OveridePathway(Pathway):
+
+    @classmethod
+    def get_icon(kls):
+        return 'fa-django'
+
+    @classmethod
+    def get_display_name(kls):
+        return 'Overridden'
+
 
 class RedirectsToPatientMixinTestCase(OpalTestCase):
 
@@ -438,6 +448,31 @@ class TestPathwayMethods(OpalTestCase):
 
     def test_get_absolute_url(self):
         self.assertEqual('/pathway/#/colourpathway/', ColourPathway.get_absolute_url())
+
+    def test_as_menuitem(self):
+        menu = ColourPathway.as_menuitem()
+        self.assertEqual('/pathway/#/colourpathway/', menu.href)
+        self.assertEqual('/pathway/#/colourpathway/', menu.activepattern)
+        self.assertEqual('fa fa-something', menu.icon)
+        self.assertEqual('colour', menu.display)
+
+    def test_as_menuitem_from_kwargs(self):
+        menu = ColourPathway.as_menuitem(
+            href="/Blue", activepattern="/B",
+            icon="fa-sea", display="Bleu"
+        )
+        self.assertEqual('/Blue', menu.href)
+        self.assertEqual('/B', menu.activepattern)
+        self.assertEqual('fa-sea', menu.icon)
+        self.assertEqual('Bleu', menu.display)
+
+    def test_as_menuitem_uses_getter_for_icon(self):
+        menu = OveridePathway.as_menuitem()
+        self.assertEqual('fa-django', menu.icon)
+
+    def test_as_menuitem_uses_getter_for_display(self):
+        menu = OveridePathway.as_menuitem()
+        self.assertEqual('Overridden', menu.display)
 
     def test_slug(self):
         self.assertEqual('colourpathway', ColourPathway().slug)

--- a/opal/core/pathway/tests/test_pathways.py
+++ b/opal/core/pathway/tests/test_pathways.py
@@ -436,6 +436,9 @@ class TestPathwayMethods(OpalTestCase):
     def test_get_slug_from_attribute(self):
         self.assertEqual('dog_owner', PathwayExample.get_slug())
 
+    def test_get_absolute_url(self):
+        self.assertEqual('/pathway/#/colourpathway/', ColourPathway.get_absolute_url())
+
     def test_slug(self):
         self.assertEqual('colourpathway', ColourPathway().slug)
 

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -2,7 +2,8 @@
 This module defines the base PatientList classes.
 """
 from opal import utils
-from opal.core import discoverable, exceptions, metadata
+from opal.utils import get
+from opal.core import discoverable, exceptions, menus, metadata
 
 
 class Column(object):
@@ -106,6 +107,19 @@ class PatientList(discoverable.DiscoverableFeature,
             return False
 
         return True
+
+    @classmethod
+    def as_menuitem(kls, **kwargs):
+        """
+        Return an instance of `opal.core.menus.MenuItem` that will
+        direct the user to this patient list.
+        """
+        return menus.MenuItem(
+            href=kwargs.get('href', kls.get_absolute_url()),
+            activepattern=kwargs.get('activepattern', kls.get_absolute_url()),
+            icon=kwargs.get('icon', get(kls, 'icon', None)),
+            display=kwargs.get('display', get(kls, 'display_name')),
+        )
 
     def get_template_prefixes(self):
         """ a patient list can return templates particular to themselves

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -84,6 +84,13 @@ class PatientList(discoverable.DiscoverableFeature,
     allow_edit_teams = True
 
     @classmethod
+    def get_absolute_url(klass, **kwargs):
+        """
+        Return the absolute URL for this list
+        """
+        return '/#/list/{0}'.format(klass.get_slug())
+
+    @classmethod
     def list(klass):
         """
         Return an iterable of Patient Lists.

--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -86,6 +86,25 @@ class TestEmptyTabbedPatientListGroup(TabbedPatientListGroup):
     member_lists = [InvisibleList]
 
 
+class IconicList(PatientList):
+    slug = 'disillusionment'
+    order = 800
+
+    @classmethod
+    def get_icon(k):
+        return "fa-james-dean"
+
+
+class DisplayList(PatientList):
+    slug = 'gastropod-mollusc'
+    order = 200
+
+    @classmethod
+    def get_display_name(k):
+        return 'Everyone'
+
+
+
 """
 Begin Tests
 """
@@ -189,6 +208,32 @@ class TestPatientList(OpalTestCase):
     def test_visible_to(self):
         self.assertTrue(TaggingTestPatientList.visible_to(self.user))
 
+    def test_as_menuitem(self):
+        href = TaggingTestPatientList.get_absolute_url()
+        menu = TaggingTestPatientList.as_menuitem()
+        self.assertEqual(menu.href, href)
+        self.assertEqual(menu.activepattern, href)
+        self.assertEqual(menu.icon, None)
+        self.assertEqual(menu.display, 'Herbivores')
+
+    def test_as_menuitem_from_kwargs(self):
+        menu = IconicList.as_menuitem(
+            href="/foo", activepattern="/f",
+            icon="fa-foo", display="Foo"
+        )
+        self.assertEqual(menu.href, '/foo')
+        self.assertEqual(menu.activepattern, '/f')
+        self.assertEqual(menu.icon, 'fa-foo')
+        self.assertEqual(menu.display, 'Foo')
+
+    def test_as_menuitem_uses_getter_for_icon(self):
+        menu = IconicList.as_menuitem()
+        self.assertEqual('fa-james-dean', menu.icon)
+
+    def test_as_menuitem_uses_getter_for_display(self):
+        menu = DisplayList.as_menuitem()
+        self.assertEqual('Everyone', menu.display)
+
     def test_schema_to_dicts(self):
         dicts = [
             {
@@ -249,6 +294,8 @@ class TestPatientList(OpalTestCase):
             TaggingTestPatientList,
             TaggingTestSameTagPatientList,
             InvisibleList,
+            DisplayList,
+            IconicList
         ]
         self.assertEqual(expected, list(PatientList.list()))
 

--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -156,6 +156,9 @@ class TestPatientList(OpalTestCase):
         with self.assertRaises(ValueError):
             queryset = PatientList().queryset
 
+    def test_get_absolute_url(self):
+        self.assertEqual('/#/list/carnivore', TaggingTestNotSubTag.get_absolute_url())
+
     def test_get_queryset_default(self):
         mock_queryset = MagicMock('Mock Queryset')
         with patch.object(PatientList, 'queryset',

--- a/opal/tests/test_utils.py
+++ b/opal/tests/test_utils.py
@@ -73,3 +73,55 @@ class WriteTestCase(OpalTestCase):
             mocksys.argv = ['not', 'te$targs']
             utils.write('this')
             mocksys.stdout.write.assert_called_with('this\n')
+
+
+class GetTestCase(OpalTestCase):
+
+    def test_get_attribute(self):
+
+        class A(object):
+            request = 'Straight, no chaser'
+
+        self.assertEqual('Straight, no chaser', utils.get(A, 'request'))
+
+    def test_get_getter(self):
+
+        class A(object):
+
+            @classmethod
+            def get_request(kls):
+                return 'Straight, no chaser'
+
+        self.assertEqual('Straight, no chaser', utils.get(A, 'request'))
+
+
+    def test_get_default(self):
+
+        class A(object):
+            pass
+
+        self.assertEqual(
+            'In The Still Of The Night',
+            utils.get(A, 'request', 'In The Still Of The Night')
+        )
+
+
+    def test_get_attribute_missing_no_default(self):
+
+        class A(object):
+            pass
+
+        with self.assertRaises(AttributeError):
+            utils.get(A, 'request')
+
+
+    def test_get_attribute_and_getter(self):
+
+        class A(object):
+            request = "I've Got You Under My Skin"
+
+            @classmethod
+            def get_request(kls):
+                return 'What Is This Thing Called Love'
+
+        self.assertEqual('What Is This Thing Called Love', utils.get(A, 'request'))

--- a/opal/tests/test_utils.py
+++ b/opal/tests/test_utils.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.db.models import ForeignKey, CharField
 from mock import patch
 
+from opal.core import exceptions
 from opal.core.test import OpalTestCase
 
 from opal import utils
@@ -105,6 +106,19 @@ class GetTestCase(OpalTestCase):
             utils.get(A, 'request', 'In The Still Of The Night')
         )
 
+    def test_get_falsy_default(self):
+
+        class A(object):
+            pass
+
+        self.assertEqual(False, utils.get(A, 'predicate', False))
+
+    def test_get_none_default(self):
+
+        class A(object):
+            pass
+
+        self.assertEqual(None, utils.get(A, 'predicate', None))
 
     def test_get_attribute_missing_no_default(self):
 
@@ -125,3 +139,11 @@ class GetTestCase(OpalTestCase):
                 return 'What Is This Thing Called Love'
 
         self.assertEqual('What Is This Thing Called Love', utils.get(A, 'request'))
+
+    def test_too_many_args(self):
+        with self.assertRaises(exceptions.SignatureError):
+            utils.get(1,2,3,3)
+
+    def test_too_few_args(self):
+        with self.assertRaises(exceptions.SignatureError):
+            utils.get(1)

--- a/opal/utils/__init__.py
+++ b/opal/utils/__init__.py
@@ -10,6 +10,7 @@ from django.template.loader import select_template
 
 from opal.core import exceptions
 
+
 def camelcase_to_underscore(string):
     return re.sub(
         '(((?<=[a-z])[A-Z])|([A-Z](?![A-Z]|$)))', '_\\1', string

--- a/opal/utils/__init__.py
+++ b/opal/utils/__init__.py
@@ -77,6 +77,10 @@ def find_template(template_list):
 
 
 def write(what):
+    """
+    Writes the argument to `sys.stdout` unless it detects an active test run.
+    If run during tests, it should do nothing.
+    """
     if 'runtests.py' in sys.argv:
         return
     sys.stdout.write("{0}\n".format(what))

--- a/opal/utils/__init__.py
+++ b/opal/utils/__init__.py
@@ -84,3 +84,21 @@ def write(what):
     if 'runtests.py' in sys.argv:
         return
     sys.stdout.write("{0}\n".format(what))
+
+
+def get(obj, attr, default=None):
+    """
+    Get an attribute named ATTR from OBJ.
+
+    If there is a `get_` method defined, use that in preference to
+    direct object accesss.
+
+    If there is no `get_` method defined and DEFAULT is passed, use
+    that as the default option for `getattr()`.
+    """
+    getter = getattr(obj, 'get_' + attr, None)
+    if getter:
+        return getter()
+    if default:
+        return getattr(obj, attr, default)
+    return getattr(obj, attr)

--- a/opal/utils/__init__.py
+++ b/opal/utils/__init__.py
@@ -8,6 +8,7 @@ import sys
 from django.template import TemplateDoesNotExist
 from django.template.loader import select_template
 
+from opal.core import exceptions
 
 def camelcase_to_underscore(string):
     return re.sub(
@@ -86,7 +87,7 @@ def write(what):
     sys.stdout.write("{0}\n".format(what))
 
 
-def get(obj, attr, default=None):
+def get(*args):
     """
     Get an attribute named ATTR from OBJ.
 
@@ -96,9 +97,23 @@ def get(obj, attr, default=None):
     If there is no `get_` method defined and DEFAULT is passed, use
     that as the default option for `getattr()`.
     """
+    if len(args) < 2:
+        msg = "Too few arguments to opal.utils.get"
+        raise exceptions.SignatureError(msg)
+    elif len(args) > 3:
+        msg = "Too many arguments to opal.utils.get"
+        raise exceptions.SignatureError(msg)
+
+    if len(args) == 3:
+        obj, attr, default = args
+        default_passed = True
+    elif len(args) == 2:
+        obj, attr = args
+        default_passed = False
+
     getter = getattr(obj, 'get_' + attr, None)
     if getter:
         return getter()
-    if default:
+    if default_passed:
         return getattr(obj, attr, default)
     return getattr(obj, attr)


### PR DESCRIPTION
Enable the `x.as_menuitem` pattern for Patient lists and pathways.

Add basic `get_absolute_url` implementation to patient lists and pathways.

Adds a `get()` utility function to look for getters.