### PR TITLE
Fail more gracefully in startp[roject|lugin] if git missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ Fonts are now served from Opal's static assets rather than from the Google CDN.
 
 Print/screen differences are now in opal.css with media tags.
 
-#### google analytics is now deferred
+#### Google Analytics is now deferred
 
 The loading in of Google Analytics is now deferred to the bottom of the body
 tag to allow the page to load without waiting on analytics scripts to load.
+
+#### Scaffold version control failures
+
+The `startplugin` and `startproject` commands initialize a git repository by
+default. If we (The `subprocess` module) cannot find the `git` command, we now
+continue with a message printed to screen rather than raising an exception.
 
 ### 0.10.0 (Major Release)
 

--- a/opal/core/scaffold.py
+++ b/opal/core/scaffold.py
@@ -57,6 +57,9 @@ def create_lookuplists(root_dir):
 
 
 def call(cmd, **kwargs):
+    """
+    Call an external program in a subprocess
+    """
     write("Calling: {}".format(' '.join(cmd)))
     try:
         subprocess.check_call(cmd, **kwargs)

--- a/opal/core/scaffold.py
+++ b/opal/core/scaffold.py
@@ -126,7 +126,11 @@ def start_plugin(name, USERLAND):
     services = jsdir/'services'
     services.mkdir()
     # 5. Initialize git repo
-    call(('git', 'init'), cwd=root, stdout=subprocess.PIPE)
+    call_if_exists(
+        ('git', 'init'),
+        'Unable to locate git; Skipping git repository initialization.',
+        cwd=root, stdout=subprocess.PIPE
+    )
 
     write('Plugin complete at {0}'.format(reponame))
     return
@@ -275,7 +279,11 @@ def start_project(name, USERLAND_HERE):
     manage('createopalsuperuser')
 
     # 10. Initialise git repo
-    call(('git', 'init'), cwd=project_dir, stdout=subprocess.PIPE)
+    call_if_exists(
+        ('git', 'init'),
+        'Unable to locate git; Skipping git repository initialization.',
+        cwd=project_dir, stdout=subprocess.PIPE
+    )
 
     # 11. Load referencedata shipped with Opal
     manage('load_lookup_lists')

--- a/opal/core/scaffold.py
+++ b/opal/core/scaffold.py
@@ -2,9 +2,11 @@
 Opal scaffolding and code generation
 """
 import inspect
+import errno
 import os
 import subprocess
 import sys
+
 from django.core import management
 from django.utils.crypto import get_random_string
 from django.apps import apps
@@ -81,7 +83,7 @@ def call_if_exists(cmd, failure_message, **kwargs):
         call(cmd, **kwargs)
         return True
     except OSError as e:
-        if e.errno == 2:
+        if e.errno == errno.ENOENT:
             write(failure_message)
             return False
         else:

--- a/opal/core/scaffold.py
+++ b/opal/core/scaffold.py
@@ -68,6 +68,26 @@ def call(cmd, **kwargs):
         sys.exit(1)
 
 
+def call_if_exists(cmd, failure_message, **kwargs):
+    """
+    Call an external program in a subprocess if it exists.
+
+    Returns True.
+
+    If it does not exist, write a failure message and return False
+    without raising an exception
+    """
+    try:
+        call(cmd, **kwargs)
+        return True
+    except OSError as e:
+        if e.errno == 2:
+            write(failure_message)
+            return False
+        else:
+            raise
+
+
 def start_plugin(name, USERLAND):
     name = name
 

--- a/opal/tests/test_scaffold.py
+++ b/opal/tests/test_scaffold.py
@@ -22,6 +22,24 @@ from opal.core.scaffold import (
 
 
 @patch('subprocess.check_call')
+class CallTestCase(OpalTestCase):
+    def test_writes_message(self, cc):
+        with patch.object(scaffold, 'write'):
+            scaffold.call(('yes', 'please'))
+            scaffold.write.assert_called_with('Calling: yes please')
+
+    def test_calls_with_args(self, cc):
+        scaffold.call(('yes', 'please'))
+        cc.assert_called_with(('yes', 'please'))
+
+    def test_exits_on_error(self, cc):
+        with patch.object(scaffold.sys, 'exit') as exiter:
+            cc.side_effect = subprocess.CalledProcessError(None, None)
+            scaffold.call(('oh' 'noes'))
+            exiter.assert_called_with(1)
+
+
+@patch('subprocess.check_call')
 class StartpluginTestCase(OpalTestCase):
     def setUp(self):
         self.path = ffs.Path.newdir()
@@ -108,6 +126,7 @@ class StartpluginTestCase(OpalTestCase):
         with open(requirements) as r:
             contents = r.read()
             self.assertIn('opal=={}'.format(opal.__version__), contents)
+
 
 @patch('subprocess.check_call')
 @patch.object(scaffold.management, 'call_command')


### PR DESCRIPTION
As reported in #1497 we are currently raising an exception in `startproject` if we can't execute `git` in a subprocess.

This change makes those failures informative message rather than a stack trace.