### PR TITLE
1494 serialisation consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Episode manager, which no longer accepts a `episode_history` kwarg.
 A refactor in the way that the core APIs are registered by Opal means that
 importing `opal.core.api` in a plugin API no longer results in circular imports.
 
+#### Episode serialization consistency
+
+Fixes a bug whereby episodes were serialising differently depending on whether
+the code path went via `.to_dict()` or `.objects.serialised()`.
 
 ### 0.10.1 (Minor Release)
 

--- a/opal/managers.py
+++ b/opal/managers.py
@@ -65,10 +65,16 @@ class EpisodeQueryset(models.QuerySet):
         in a nested hashtable where the outer key is the episode id,
         the inner key the subrecord API name.
         """
-        episode_subs = defaultdict(lambda: defaultdict(list))
+        episode_subs = defaultdict(dict)
+        episode_ids = [e.id for e in episodes]
 
         for model in episode_subrecords():
             name = model.get_api_name()
+
+            # Ensure there is an empty list for serialisation
+            for episode_id in episode_ids:
+                episode_subs[episode_id][name] = []
+
             subrecords = prefetch(
                 model.objects.filter(episode__in=episodes)
             )
@@ -78,6 +84,7 @@ class EpisodeQueryset(models.QuerySet):
 
             for sub in subrecords:
                 episode_subs[sub.episode_id][name].append(sub.to_dict(user))
+
         return episode_subs
 
     def serialised(self, user, episodes, historic_tags=False):
@@ -87,11 +94,15 @@ class EpisodeQueryset(models.QuerySet):
         If HISTORIC_TAGS is Truthy, return deleted tags as well.
         """
         patient_ids = [e.patient_id for e in episodes]
-        patient_subs = defaultdict(lambda: defaultdict(list))
+        patient_subs = defaultdict(dict)
 
         episode_subs = self.serialised_episode_subrecords(episodes, user)
         for model in patient_subrecords():
             name = model.get_api_name()
+
+            for patient_id in patient_ids:
+                patient_subs[patient_id][name] = []
+
             subrecords = prefetch(
                 model.objects.filter(patient__in=patient_ids)
             )

--- a/opal/models.py
+++ b/opal/models.py
@@ -874,27 +874,27 @@ class Episode(UpdatesFromDictMixin, TrackedModel):
         for model in patient_subrecords():
             subrecords = model.objects.filter(patient_id=self.patient.id)
 
-            if subrecords:
-                d[model.get_api_name()] = [
-                    subrecord.to_dict(user) for subrecord in subrecords
-                ]
+            d[model.get_api_name()] = [
+                subrecord.to_dict(user) for subrecord in subrecords
+            ]
+
         for model in episode_subrecords():
             subrecords = model.objects.filter(episode_id=self.id)
 
-            if subrecords:
-                d[model.get_api_name()] = [
-                    subrecord.to_dict(user) for subrecord in subrecords
-                ]
+            d[model.get_api_name()] = [
+                subrecord.to_dict(user) for subrecord in subrecords
+            ]
 
         d['tagging'] = self.tagging_dict(user)
         return d
 
 
 class Subrecord(UpdatesFromDictMixin, ToDictMixin, TrackedModel, models.Model):
-    consistency_token = models.CharField(max_length=8)
-    _is_singleton = False
-    _advanced_searchable = True
+    _is_singleton            = False
+    _advanced_searchable     = True
     _exclude_from_subrecords = False
+
+    consistency_token = models.CharField(max_length=8)
 
     class Meta:
         abstract = True

--- a/opal/tests/test_models.py
+++ b/opal/tests/test_models.py
@@ -45,6 +45,11 @@ class PatientTestCase(OpalTestCase):
         self.assertEqual(models.Episode, episode.__class__)
         self.assertEqual(patient, episode.patient)
 
+    def test_to_dict_episode_identical_to_episode_to_dict(self):
+        patient, episode = self.new_patient_and_episode_please()
+        episode_dict = episode.to_dict(self.user)
+        self.assertEqual(episode_dict, patient.to_dict(self.user)['episodes'][episode.id])
+
     @patch("opal.models.application.get_app")
     def test_created_with_the_default_episode(self, get_app):
         test_app = MagicMock()


### PR DESCRIPTION
Everything should serialise episodes in the same way.
That way should include keys for subrecords even if the Episode/Patient does not have any related subrecords.

closes #1494 