### PR TITLE
1502 test options bugfix

### DIFF
--- a/opal/core/test_runner.py
+++ b/opal/core/test_runner.py
@@ -32,21 +32,21 @@ def _run_py_tests(args):
     if _has_file(args.userland_here, 'runtests.py'):
         test_args = ['python', 'runtests.py']
 
-        if args.test:
-            test_args.append(args.test)
-
         if args.coverage:
             test_args = ['coverage', 'run', 'runtests.py']
+
+        if args.test:
+            test_args.append(args.test)
 
     # We have a manage.py script - assume that we're in an application
     elif _has_file(args.userland_here, 'manage.py'):
         test_args = ['python', 'manage.py', 'test']
 
-        if args.test:
-            test_args.append(args.test)
-
         if args.coverage:
             test_args = ['coverage', 'run', 'manage.py', 'test', ]
+
+        if args.test:
+            test_args.append(args.test)
 
     else:
         write("\n\nCripes!\n")

--- a/opal/tests/test_core_test_runner.py
+++ b/opal/tests/test_core_test_runner.py
@@ -60,6 +60,19 @@ class RunPyTestsTestCase(OpalTestCase):
         check_call.assert_has_calls(calls)
 
     @patch('subprocess.check_call')
+    def test_run_tests_with_coverage_and_test_arg(self, check_call):
+        mock_args = MagicMock(name="args")
+        mock_args.userland_here = ffs.Path('.')
+        mock_args.coverage = True
+        mock_args.test = 'opal.tests.foo'
+        mock_args.failfast = False
+        test_runner._run_py_tests(mock_args)
+        calls = [
+            call(['coverage', 'run', 'runtests.py', 'opal.tests.foo']),
+            call(['coverage', 'html'])
+        ]
+
+    @patch('subprocess.check_call')
     @patch.object(test_runner.sys, 'exit')
     def test_run_tests_with_coverage_errors(self, exiter, check_call):
         mock_args = MagicMock(name="args")


### PR DESCRIPTION
If we move the order in which we construct the subprocess string, you get to combine `-t` and `-c`.

closes #1502