### PR TITLE
Fixup: Pin pip version in Appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,9 @@ environment:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  # This is only pinning to a version rather than --upgrade pip until
+  # such times as the latest Pip doesn't error out with `cannot import name main`
+  - "pip install --disable-pip-version-check --user pip==9.0.3"
   - "%CMD_IN_ENV% python setup.py develop"
   - "pip install -r test-requirements.txt"
 


### PR DESCRIPTION
At some stage we should attempt to discover why pip 10.0.0 doesn't run on Appveyor.

For now, I'd just quite like to be able to merge PRs and build things on windows.