### PR TITLE
Add a custom meta path to allow us to import subrecords by name regardless of their actual location in a file.

### DIFF
--- a/opal/__init__.py
+++ b/opal/__init__.py
@@ -2,6 +2,7 @@
 Opal is a package
 """
 from opal._version import __version__
+from opal.core import meta_path  # noqa: F401
 
 __all__ = [
     '__version__'

--- a/opal/core/meta_path.py
+++ b/opal/core/meta_path.py
@@ -1,0 +1,28 @@
+"""
+Opal "magic" modules
+"""
+import sys
+import types
+
+
+class DynamicSubrecordModule(types.ModuleType):
+    def __getattr__(self, attr):
+        from opal.core import subrecords
+        try:
+            return subrecords.get_subrecord_from_model_name(attr)
+        except ValueError:
+            pass  # No subrecord found - use the default response
+        return getattr(types.ModuleType, attr)
+
+
+class ApplicationSubrecordImporter(object):
+    def find_module(self, fullname, path=None):
+        if fullname == 'opal.application_subrecords':
+            return self
+        return None
+
+    def load_module(self, name):
+        return DynamicSubrecordModule(name)
+
+
+sys.meta_path.append(ApplicationSubrecordImporter())

--- a/opal/tests/test_core_meta_path.py
+++ b/opal/tests/test_core_meta_path.py
@@ -1,0 +1,55 @@
+"""
+Unittests for opal.core.meta_path
+"""
+from opal.core.test import OpalTestCase
+
+from opal.tests import models
+from opal.tests.models import Birthday
+
+from opal.core import meta_path
+
+class DynamicSubrecordModuleTestCase(OpalTestCase):
+
+    def test_existing_subrecord(self):
+        bd = meta_path.DynamicSubrecordModule(
+            'opal.application_subrecords'
+        ).Birthday
+        self.assertEqual(Birthday, bd)
+
+    def test_missing_subrecord(self):
+        with self.assertRaises(AttributeError):
+            module = meta_path.DynamicSubrecordModule(
+                'opal.application_subrecords'
+            )
+            Mule = module.Mule
+
+
+class ApplicationSubrecordImporterTestCase(OpalTestCase):
+
+    def test_find_module_in_namespace(self):
+        importer = meta_path.ApplicationSubrecordImporter()
+        found = importer.find_module('opal.application_subrecords')
+        self.assertEqual(found, importer)
+
+    def test_find_module_outside_namespace(self):
+        importer = meta_path.ApplicationSubrecordImporter()
+        self.assertEqual(
+            None,
+            importer.find_module('bpython')
+        )
+
+    def test_load_module(self):
+        importer = meta_path.ApplicationSubrecordImporter()
+        module = importer.load_module('opal.application_subrecords')
+        self.assertIsInstance(module, meta_path.DynamicSubrecordModule)
+
+
+class ImportSyntaxTestCase(OpalTestCase):
+
+    def test_import(self):
+        from opal.application_subrecords import Dinner
+        self.assertEqual(models.Dinner, Dinner)
+
+    def test_import_as(self):
+        from opal.application_subrecords import HouseOwner as LandedGentry
+        self.assertEqual(models.HouseOwner, LandedGentry)


### PR DESCRIPTION
For now, I propose adding this as an undocumented, not officially supported helper / syntax sweetner.

See how we feel about it and then if it seems useful we can document/support it.

refs #801