### PR TITLE
1520 refactor the switcher dropdown

### DIFF
--- a/doc/docs/guides/list_views.md
+++ b/doc/docs/guides/list_views.md
@@ -200,7 +200,11 @@ top of any list in the group.
 
 ### Defining a Tabbed Patient List Group
 
-Defining a group can be as simple as declaring member lists in a property.
+To define a group, declare the `member_lists` in Python list. Each item in the `member_lists` should be an object of class PatientList.
+
+You also need to define a `default_tab`, which specifies which of the member PatientLists you want  be shown initially by default when you select the Tab Group in the dropdown list Switcher.
+
+And finally, also specify a `display_name` for the TabbedPatientListGroup, which is what will be shown in the list Switcher dropdown menu.
 
 ```python
 # yourapp/patient_lists.py
@@ -211,6 +215,8 @@ from opal.core import patient_lists
 
 class MyListGroup(patient_lists.TabbedPatientListGroup):
     member_lists = [MyFirstPatientList, MySecondPatientList, ...]
+    display_name = "My Tabbed Group"
+    default_tab = MySecondPatientList
 ```
 
 

--- a/doc/docs/reference/patient_list.md
+++ b/doc/docs/reference/patient_list.md
@@ -80,6 +80,12 @@ The child tag for this list. Should be lowercase, with no numbers or dashes. Und
 Groups Patient Lists together, to display as tabs at the top of any list in the group.
 ![patientlist-tabbed-view](../img/patientlist-tabbed-view.png).
 
+#### TabbedPatientListGroup.default_tab
+**Required** property which specifies which of the member `PatientList`s should be shown when the tab is selected. Must be a `PatientList` and must be in `member_lists`.
+
+#### TabbedPatientListGroup.display_name
+**Required** property which defines the name to be displayed in the list Switcher to represent the TabbedPatientListGroup
+
 #### TabbedPatientListGroup.for_list
 Returns the group for a given PatientList. Raises ValueError if not passed a PatientList.
 
@@ -94,6 +100,7 @@ A list containing the `PatientList` subclasses in this group.
 
 #### TabbedPatientListGroup.visible_to
 Predicate function to determine whether this list is meaningfully visible to this user.
+
 
 
 

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -211,7 +211,10 @@ Sometimes we group lists for display purposes.
 class TabbedPatientListGroup(discoverable.DiscoverableFeature):
     """
     Groups of Patient Lists to display as tabs at the top of
-    any list in the group
+    any list in the group.
+
+    display_name for the Tab Group must be defined
+    default_tab for the Tab Group must be defined
     """
     module_name   = 'patient_lists'
     member_lists  = []
@@ -232,6 +235,16 @@ class TabbedPatientListGroup(discoverable.DiscoverableFeature):
         for group in klass.list():
             if patient_list in group.get_member_lists():
                 return group
+
+    # uses the value of default_tab to return a default slug
+    # last viewed tab is cached by the frontend and replaces default_tab once set
+    @classmethod
+    def get_slug(klass):
+        msg = 'TabbedPatientListGroup must have a default_tab property'
+        if klass.default_tab:
+            return klass.default_tab.get_slug()
+        else:
+            raise ValueError(msg)
 
     @classmethod
     def get_member_lists(klass):
@@ -262,6 +275,7 @@ class TabbedPatientListGroup(discoverable.DiscoverableFeature):
         if len(list(klass.get_member_lists_for_user(user))) > 1:
             return True
         return False
+
 
 
 """

--- a/opal/templates/patient_lists/partials/list_dropdown_menu.html
+++ b/opal/templates/patient_lists/partials/list_dropdown_menu.html
@@ -1,5 +1,6 @@
 {% load forms %}
-{% if num_lists > 1 %}
+<!-- suppress the Switcher if there are no items in it -->
+<!-- {% if switcher_items != None %}
 <div class="btn-group pull-left" uib-dropdown is-open="status.isopen">
   <button type="button" class="btn btn-secondary" uib-dropdown-toggle ng-disabled="disabled" id="list-dropdown">
     <i class="fa fa-user-md"></i>
@@ -7,15 +8,13 @@
     <i class="fa fa-angle-down"></i>
   </button>
   <ul class="uib-dropdown-menu slides" role="menu" aria-labelledby="list-dropdown">
-    {% for list in lists %}
-    {% if list.get_slug != list_slug %}
+    {% for item in switcher_items %}
     <li>
-      <a href="#/list/{{ list.get_slug }}">
-        {{ list.display_name }}
+      <a href="#/list/{{ item.get_slug }}">
+        {{ item.display_name }}
       </a>
     </li>
-    {% endif %}
     {% endfor %}
   </ul>
 </div>
-{% endif %}
+{% endif %} -->

--- a/opal/templates/patient_lists/partials/list_dropdown_menu.html
+++ b/opal/templates/patient_lists/partials/list_dropdown_menu.html
@@ -1,12 +1,17 @@
 {% load forms %}
+
 <!-- suppress the Switcher if there are no items in it -->
-<!-- {% if switcher_items != None %}
+{% if switcher_items != None %}
 <div class="btn-group pull-left" uib-dropdown is-open="status.isopen">
+
+  <!-- displays the name of the currently viewed item on the Switcher button -->
   <button type="button" class="btn btn-secondary" uib-dropdown-toggle ng-disabled="disabled" id="list-dropdown">
     <i class="fa fa-user-md"></i>
     {{ patient_list.display_name }}
     <i class="fa fa-angle-down"></i>
   </button>
+
+  <!-- displays the available Switcher items in the dropdown menu -->
   <ul class="uib-dropdown-menu slides" role="menu" aria-labelledby="list-dropdown">
     {% for item in switcher_items %}
     <li>
@@ -16,5 +21,6 @@
     </li>
     {% endfor %}
   </ul>
+
 </div>
-{% endif %} -->
+{% endif %}

--- a/opal/tests/test_views.py
+++ b/opal/tests/test_views.py
@@ -114,6 +114,9 @@ class PatientListTemplateViewTestCase(BaseViewTestCase):
 
         context_data = view.get_context_data(slug="eater-herbivore")
         expected = list(patient_lists.PatientList.for_user(self.user))
+        # this test is failing because the `expected` items no longer match the
+        # values returned by the new get_context_data() method. I'm not sure whether to
+        # replicate the processing of get_switcher_items() in here, or not. Discuss.
         self.assertEqual(expected, list(context_data['switcher_items']))
 
     def test_get_context_data_list_group(self):

--- a/opal/tests/test_views.py
+++ b/opal/tests/test_views.py
@@ -150,15 +150,6 @@ class PatientListTemplateViewTestCase(BaseViewTestCase):
         context_data = view.get_context_data(slug="carnivore")
         self.assertEqual(None, context_data['list_group'])
 
-    def test_get_context_data_list_slug(self):
-        url = reverse("patient_list_template_view", kwargs=dict(slug="eater-herbivore"))
-        request = self.get_request(url)
-        view = self.setup_view(views.PatientListTemplateView, request, slug="eater-herbivore")
-        view.patient_list = TaggingTestPatientList
-
-        context_data = view.get_context_data(slug="eater-herbivore")
-        self.assertEqual('eater-herbivore', context_data['list_slug'])
-
     def test_get_context_data_list_slug_no_list(self):
         url = reverse("patient_list_template_view", kwargs=dict(slug="eater-herbivore"))
         request = self.get_request(url)

--- a/opal/tests/test_views.py
+++ b/opal/tests/test_views.py
@@ -150,15 +150,6 @@ class PatientListTemplateViewTestCase(BaseViewTestCase):
         context_data = view.get_context_data(slug="carnivore")
         self.assertEqual(None, context_data['list_group'])
 
-    def test_get_context_data_list_slug_no_list(self):
-        url = reverse("patient_list_template_view", kwargs=dict(slug="eater-herbivore"))
-        request = self.get_request(url)
-        view = self.setup_view(views.PatientListTemplateView, request, slug="eater-herbivore")
-        view.patient_list = None
-
-        context_data = view.get_context_data()
-        self.assertEqual(None, context_data['list_slug'])
-
     def test_get_column_context_no_list(self):
         view = views.PatientListTemplateView()
         view.patient_list = None

--- a/opal/tests/test_views.py
+++ b/opal/tests/test_views.py
@@ -114,16 +114,7 @@ class PatientListTemplateViewTestCase(BaseViewTestCase):
 
         context_data = view.get_context_data(slug="eater-herbivore")
         expected = list(patient_lists.PatientList.for_user(self.user))
-        self.assertEqual(expected, list(context_data['lists']))
-
-    def test_get_context_data_num_lists(self):
-        url = reverse("patient_list_template_view", kwargs=dict(slug="eater-herbivore"))
-        request = self.get_request(url)
-        view = self.setup_view(views.PatientListTemplateView, request, slug="eater-herbivore")
-        view.patient_list = TaggingTestPatientList
-
-        context_data = view.get_context_data(slug="eater-herbivore")
-        self.assertIsInstance(context_data['num_lists'], int)
+        self.assertEqual(expected, list(context_data['switcher_items']))
 
     def test_get_context_data_list_group(self):
         url = reverse("patient_list_template_view", kwargs=dict(slug="eater-herbivore"))

--- a/opal/views.py
+++ b/opal/views.py
@@ -50,14 +50,16 @@ class PatientListTemplateView(LoginRequiredMixin, TemplateView):
         context = super(
             PatientListTemplateView, self
         ).get_context_data(**kwargs)
-        list_slug = None
-        if self.patient_list:
-            list_slug = self.patient_list.get_slug()
-        context['list_slug'] = list_slug
+        # list_slug = None
+        # if self.patient_list:
+        #     list_slug = self.patient_list.get_slug()
+        # context['list_slug'] = list_slug
         context['patient_list'] = self.patient_list
-        context['lists'] = list(PatientList.for_user(self.request.user))
-        context['num_lists'] = len(context['lists'])
-
+        context['switcher_items'] = self.get_switcher_items(
+                                        self.request.user,
+                                        self.patient_list,
+                                    )
+        # context['num_lists'] = len(context['lists'])
         context['list_group'] = None
         if self.patient_list:
             group = TabbedPatientListGroup.for_list(self.patient_list)
@@ -67,6 +69,20 @@ class PatientListTemplateView(LoginRequiredMixin, TemplateView):
 
         context['columns'] = self.get_column_context(**kwargs)
         return context
+
+    def get_switcher_items(self, current_user, currently_displayed_list):
+        # get all the PatientList items that the current user can 'see'
+        items = list(PatientList.for_user(current_user))
+        # get all the TabbedPatientListGroup items that the current user can 'see'
+
+        # remove the current list from switcher items
+        if currently_displayed_list in items:
+            items.remove(currently_displayed_list)
+
+        # list switcher is suppressed in the template if there are no items
+
+        # pass a processed list of switcher items to the front end
+        return items
 
     def get_template_names(self):
         if self.patient_list:

--- a/opal/views.py
+++ b/opal/views.py
@@ -50,23 +50,17 @@ class PatientListTemplateView(LoginRequiredMixin, TemplateView):
         context = super(
             PatientListTemplateView, self
         ).get_context_data(**kwargs)
-        # list_slug = None
-        # if self.patient_list:
-        #     list_slug = self.patient_list.get_slug()
-        # context['list_slug'] = list_slug
         context['patient_list'] = self.patient_list
         context['switcher_items'] = self.get_switcher_items(
                                         self.request.user,
                                         self.patient_list,
                                     )
-        # context['num_lists'] = len(context['lists'])
         context['list_group'] = None
         if self.patient_list:
             group = TabbedPatientListGroup.for_list(self.patient_list)
             if group:
                 if group.visible_to(self.request.user):
                     context['list_group'] = group
-
         context['columns'] = self.get_column_context(**kwargs)
         return context
 


### PR DESCRIPTION
* Brings together all processing of the contents of the Switcher into views.py and out of templates.

* Removes `list_slug` which was only being used to suppress the currently viewed list from the dropdown menu - this is now handled in views.py logic

* Removes `num_lists` which was being used in the template to suppress the display of the Switcher in the case when there is only one list. This is also now handled in views.py logic

* Introduces `default_tab` and `display_name` as required properties of a TabbedPatientListGroup. TPLGs are represented on the Switcher by their `display_name` and the `default_tab` is used to generate an initial `slug`. (The plan is that the frontend will cache the last visited tab and this will over-ride the default, but this is not yet implemented)

* Adds documentation for the new properties `default_tab` and `display_name`.

* edited `test_views.py` mainly to remove the test cases which test for `list_slug` and `num_lists`, as these are no longer used. There is still a [failing test](https://github.com/openhealthcare/opal/blob/5ca6d4d143d5f9d7960ee14b01fb14dc208a7d06/opal/tests/test_views.py#L109) which I am unsure how best to fix.

* I have tried to minimise my use of the term PatientList in describing what entities can be part of a Tab Group, and what can be in the switcher. [In the future we may want to be able to include (a subset of?) all `Discoverable` features (and maybe others like Dashboards) in the Switcher and in Tab Groups?]