### PR TITLE
1535 inline date options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### 0.11.0 (Major Release)
 
+#### Adds options of `today` and `yesterday` in the date picker
+If you pass in `options=1` to the date picker. You will be provided with options to select today or yesterday in the form tag.
+
 #### Removes "episode_history" from episode serialization
 
 Serialised episodes previously contained a "shallow" copy of all other episodes in

--- a/doc/docs/reference/form_templatetags.md
+++ b/doc/docs/reference/form_templatetags.md
@@ -44,6 +44,7 @@ Keywords:
 * `mindate` Angular Javascript expression to return the minimum possible date
 * `element_name` If this exists this is an Angular expression that is set to the 'name' attribute of the html element
 * `style` The form style to render this widget with. Possible values are `['horizontal', 'vertical']`. Defaults to 'horizontal'
+* `options` If set to `True` this will add the default options of `today`, ie the current date, or `yesterday`, ie t-1.
 
 
 ### {% timepicker ... %}

--- a/opal/core/pathway/static/js/pathway/controllers/modal_pathway_ctrl.js
+++ b/opal/core/pathway/static/js/pathway/controllers/modal_pathway_ctrl.js
@@ -19,6 +19,8 @@ angular.module('opal.controllers').controller('ModalPathwayCtrl', function(
         pathwayDefinition.pathway_service
     );
     $scope.pathway = new pathwayService(pathwayDefinition, episode);
+    $scope.now = new Date();
+    $scope.yesterday = moment().subtract(1, 'days').toDate();
     $scope.editing = $scope.pathway.populateEditingDict(episode);
     var analyticsKwargs = {
       category: "ModalPathway"

--- a/opal/core/pathway/static/js/pathway/controllers/pathway_ctrl.js
+++ b/opal/core/pathway/static/js/pathway/controllers/pathway_ctrl.js
@@ -11,6 +11,8 @@ angular.module('opal.controllers').controller('PathwayCtrl', function(
     $scope.metadata = metadata;
     _.extend($scope, referencedata.toLookuplists());
     $scope.episode = episode;
+    $scope.now = new Date();
+    $scope.yesterday = moment().subtract(1, 'days').toDate();
     var pathwayService = $injector.get(
         pathwayDefinition.pathway_service
     );

--- a/opal/static/css/opal.css
+++ b/opal/static/css/opal.css
@@ -196,9 +196,6 @@ h1.larger { font-size: 52px; }
 .content-offset-below-10 {
     margin-bottom: 10px;
 }
-.content-offset-5{
-    margin-top: 5px;
-}
 .content-offset-75 {margin-top: 75px; }
 .content-centered { padding-top: 20%; height: 100%; }
 .heading { position: fixed; top: 50px; width: 100%; z-index: 3; }
@@ -1219,7 +1216,6 @@ hr.bold{
   overflow-y: auto;
 }
 
-.btn.btn-opal-xs{
-  font-size: 12px;
-  padding: 2px 5px;
+.input-group-btn .btn{
+  padding: 8.5px 12px;
 }

--- a/opal/static/css/opal.css
+++ b/opal/static/css/opal.css
@@ -196,6 +196,9 @@ h1.larger { font-size: 52px; }
 .content-offset-below-10 {
     margin-bottom: 10px;
 }
+.content-offset-5{
+    margin-top: 5px;
+}
 .content-offset-75 {margin-top: 75px; }
 .content-centered { padding-top: 20%; height: 100%; }
 .heading { position: fixed; top: 50px; width: 100%; z-index: 3; }
@@ -1214,4 +1217,9 @@ hr.bold{
   min-height: 150px;
   max-height: 150px;
   overflow-y: auto;
+}
+
+.btn.btn-opal-xs{
+  font-size: 12px;
+  padding: 2px 5px;
 }

--- a/opal/static/js/opal/controllers/edit_item.js
+++ b/opal/static/js/opal/controllers/edit_item.js
@@ -15,6 +15,8 @@ angular.module('opal.controllers').controller(
             $scope.editing[item.columnName] = item.makeCopy();
             $scope.metadata = metadata
 
+            $scope.now = new Date();
+            $scope.yesterday = moment().subtract(1, 'days').toDate();
             $scope.editingMode = function(){
                 return !_.isUndefined($scope.editing[item.columnName].id);
             };

--- a/opal/static/js/opal/filters.js
+++ b/opal/static/js/opal/filters.js
@@ -164,6 +164,14 @@ filters.filter('daysSince', function(daysToFilter){
     };
 });
 
+filters.filter('sameDate', function(toMomentFilter){
+		return function(d1, d2){
+			if(d1 & d2){
+				return toMomentFilter(d1).isSame(toMomentFilter(d2, 'day'));
+			}
+		};
+});
+
 
 filters.filter('future', function(){
     return function(i, includeToday){

--- a/opal/static/js/test/edit_item.controller.test.js
+++ b/opal/static/js/test/edit_item.controller.test.js
@@ -81,6 +81,18 @@ describe('EditItemCtrl', function (){
             "investigation", {category: "EditItem", label: "Inpatient"}
           );
       });
+
+      it('should put now on the scope', function(){
+        expect(!!$scope.now).toBe(true);
+        var now = moment($scope.now);
+        expect(now.isSame(moment(), 'minute')).toBe(true);
+      });
+
+      it('should put now on the scope', function(){
+        expect(!!$scope.yesterday).toBe(true);
+        var yesterday = moment().subtract(1, "day");
+        expect(moment($scope.yesterday).isSame(yesterday, 'minute')).toBe(true);
+      });
     })
 
     describe('editingMode()', function() {

--- a/opal/static/js/test/filters.test.js
+++ b/opal/static/js/test/filters.test.js
@@ -315,6 +315,34 @@ describe('filters', function() {
 
     });
 
+    describe('sameDate', function(){
+
+      var sameDateFilter, today, yesterday, tomorrow;
+
+      beforeEach(function(){
+          inject(function($injector){
+              sameDateFilter = $injector.get('sameDateFilter');
+          });
+          today = moment().toDate();
+          yesterday = moment().subtract(1, 'days').toDate();
+      });
+
+      it('should return undefined if either of the dates is not set', function(){
+        expect(sameDateFilter(undefined, today)).toBe(undefined);
+        expect(sameDateFilter(today, undefined)).toBe(undefined);
+        expect(sameDateFilter(undefined, undefined)).toBe(undefined);
+      });
+
+      it("should return false if the dates are not the same", function(){
+        expect(sameDateFilter(yesterday, today)).toBe(false);
+        expect(sameDateFilter(today, yesterday)).toBe(false);
+      });
+
+      it("should return true if the dates are not the same", function(){
+        expect(sameDateFilter(moment().toDate(), today)).toBe(true);
+      });
+    });
+
     describe('future', function(){
         var futureFilter, today;
 

--- a/opal/templates/_helpers/datepicker.html
+++ b/opal/templates/_helpers/datepicker.html
@@ -10,31 +10,31 @@
     class="col-sm-8"
     {% endifequal %}
     >
-    <input type="text" class="form-control"
-           uib-datepicker-popup="dd/MM/yyyy"
-           ng-model="{{ model }}"
-           is-open="{{ formname }}[{{ element_name }} + '_open']"
-           min-date="{{ mindate}}"
-           max-date="maxDate"
-           show-button-bar="false"
-           show-weeks="false"
-           name="[[ {{ element_name}} ]]"
-           datepicker-options="{startingDay: 1}"
-           ng-focus="{{ formname }}[{{ element_name }} + '_open']=true"
-           close-text="Close"
-           {% if change %}
-           ng-change="{{ change }}"
-           {% endif %}
-           />
+    {% if options %}
+      <div class="input-group">
+    {% endif %}
+        <input type="text" class="form-control"
+               uib-datepicker-popup="dd/MM/yyyy"
+               ng-model="{{ model }}"
+               is-open="{{ formname }}[{{ element_name }} + '_open']"
+               min-date="{{ mindate}}"
+               max-date="maxDate"
+               show-button-bar="false"
+               show-weeks="false"
+               name="[[ {{ element_name}} ]]"
+               datepicker-options="{startingDay: 1}"
+               ng-focus="{{ formname }}[{{ element_name }} + '_open']=true"
+               close-text="Close"
+               {% if change %}
+               ng-change="{{ change }}"
+               {% endif %}
+               />
+     {% if options %}
+         <span class="input-group-btn">
+           <button type="button" class="btn btn-default" ng-click="{{ model }} = now" href="">Today</a>
+           <button type="button" class="btn btn-default" ng-click="{{ model }} = yesterday" href="">Yesterday</a>
+         </span>
+       </div>
+     {% endif %}
   </div>
-  {% if options %}
-    <div class="row">
-      <div class="col-sm-12 content-offset-5">
-        <div class="col-sm-8 col-sm-push-3">
-          <a ng-class="{active: ({{ model }}|sameDate: now)}" class="btn btn-primary btn-opal-xs" ng-click="{{ model }} = now" href="">Today</a>
-          <a ng-class="{active: ({{ model }}|sameDate: yesterday)}" class="btn btn-primary btn-opal-xs" ng-click="{{ model }} = yesterday" href="">Yesterday</a>
-        </div>
-      </div>
-    </div>
-  {% endif %}
 </div>

--- a/opal/templates/_helpers/datepicker.html
+++ b/opal/templates/_helpers/datepicker.html
@@ -27,4 +27,14 @@
            {% endif %}
            />
   </div>
+  {% if options %}
+    <div class="row">
+      <div class="col-sm-12 content-offset-5">
+        <div class="col-sm-8 col-sm-push-3">
+          <a ng-class="{active: ({{ model }}|sameDate: now)}" class="btn btn-primary btn-opal-xs" ng-click="{{ model }} = now" href="">Today</a>
+          <a ng-class="{active: ({{ model }}|sameDate: yesterday)}" class="btn btn-primary btn-opal-xs" ng-click="{{ model }} = yesterday" href="">Yesterday</a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
 </div>

--- a/opal/templatetags/forms.py
+++ b/opal/templatetags/forms.py
@@ -216,6 +216,7 @@ def datepicker(*args, **kwargs):
     context = _input(*args, **kwargs)
     if 'mindate' in kwargs:
         context['mindate'] = kwargs['mindate']
+    context["options"] = kwargs.pop("options", False)
     return context
 
 

--- a/opal/tests/test_templatetags_forms.py
+++ b/opal/tests/test_templatetags_forms.py
@@ -295,6 +295,16 @@ class DatepickerTestCase(TestCase):
         self.assertIn('ng-model="bai"', rendered)
         self.assertIn('hai', rendered)
 
+    def test_datepicker_options_default(self):
+        template = Template('{% load forms %}{% datepicker label="hai" model="bai" mindate="Date(2013, 12, 22)" %}')
+        rendered = template.render(Context({}))
+        self.assertNotIn('bai = now', rendered)
+
+    def test_datepicker_options_on(self):
+        template = Template('{% load forms %}{% datepicker label="hai" model="bai" mindate="Date(2013, 12, 22)" options=True %}')
+        rendered = template.render(Context({}))
+        self.assertIn('bai = now', rendered)
+
     def test_datepicker_min_date(self):
         template = Template('{% load forms %}{% datepicker label="hai" model="bai" mindate="Date(2013, 12, 22)" %}')
         rendered = template.render(Context({}))


### PR DESCRIPTION
I think I prefer it with the active blue when `today`/`yesterday` is picked, but I'm not sure how I'd deal with 'now' so lets start off with this. The blue can come in as an enhancement if we want it.

<img width="912" alt="screen shot 2018-06-15 at 10 36 57" src="https://user-images.githubusercontent.com/2175455/41461605-1210c972-7088-11e8-8057-8cf9aefea2c5.png">
<img width="913" alt="screen shot 2018-06-15 at 10 36 52" src="https://user-images.githubusercontent.com/2175455/41461607-12275002-7088-11e8-8477-0955a04b1583.png">
<img width="912" alt="screen shot 2018-06-15 at 10 36 40" src="https://user-images.githubusercontent.com/2175455/41461608-123e4dfc-7088-11e8-8526-6c24ecfd35c3.png">
