### PR TITLE
Make sure the make docs command works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 
 docs:
 	pip install -r doc/requirements.txt
-	mkdocs serve
+	cd doc && mkdocs serve
 
 release:
 	rm -rf dist/*


### PR DESCRIPTION
When running `make docs` the command can't find the mkdocs.yml config
file (it's in doc/).  If you run the command from the doc/ folder, then
make can't see the Makefile.

This PR just makes make make a change in directory before running the
task.

Fixes #1547 