### PR TITLE
Patient demographics property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ a generator function which will yield all subrecord singletons.
 made hospital numbers including `#` or `/` raise an error.
 * Adds the methods `.get_absolute_url()`, `.get_icon()` and `get_display_name()`
 to `opal.core.pathways.Pathway` and `opal.core.patient_lists.PatientList`.
-* Adds a property `.demographics` to `opal.models.Patient` which returns the relevant
+* Adds a method `.demographics()` to `opal.models.Patient` which returns the relevant
 demographics instance.
 
 #### Updates to the Dependency Graph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ### 0.11.0 (Major Release)
 
 #### Adds options of `today` and `yesterday` in the date picker
-If you pass in `user_options=True` to the date picker. You will be provided with options to select today or yesterday in the form tag.
+
+If you pass in `user_options=True` to the date picker. You will be provided with
+options to select today or yesterday in the form tag.
 
 #### Adds `dateHelper` to the rootScope
+
 The dateHelper has the functions `now` and `yesterday` that return javascript Dates for
 the current time and the current time - 1 day.
 
@@ -21,11 +24,13 @@ Fixes a bug whereby episodes were serialising differently depending on whether
 the code path went via `.to_dict()` or `.objects.serialised()`.
 
 #### HelpTextStep can now use a custom template
+
 The `opal.core.pathway.steps.HelpTextStep` can now have a `help_text_template` passed in.
 
 This is the template for what will be placed in the side bar.
 
 #### Adds in a radio_vertical template tag
+
 This displays the label and then the radio
 buttons as a vertical list.
 
@@ -65,7 +70,6 @@ for a method named `get_$attr` and will call that if it exists.
 Adds the method `.get_absolute_url()` to `opal.core.pathways.Pathway` and
 `opal.core.patient_lists.PatientList`.
 
-
 #### Template removals
 
 We removed a number of superfluous templates:
@@ -96,10 +100,10 @@ override `base.html`in your application we advise that you add this `<meta>` tag
 a generator function which will yield all subrecord singletons.
 * Fixes a URI encoding bug in the `Episode.findByHospitalNumber()` method that
 made hospital numbers including `#` or `/` raise an error.
-
 * Adds the methods `.get_absolute_url()`, `.get_icon()` and `get_display_name()`
 to `opal.core.pathways.Pathway` and `opal.core.patient_lists.PatientList`.
-
+* Adds a property `.demographics` to `opal.models.Patient` which returns the relevant
+demographics instance.
 
 #### Updates to the Dependency Graph
 

--- a/doc/docs/reference/patient.md
+++ b/doc/docs/reference/patient.md
@@ -1,12 +1,10 @@
 ## opal.models.Patient
 
-### properties
+### methods
 
-#### `Patient.demographics`
+#### `Patient.demographics()`
 
 Returns the relevant Demographics instance for the patient.
-
-### methods
 
 #### `Patient.create_episode()`
 

--- a/doc/docs/reference/patient.md
+++ b/doc/docs/reference/patient.md
@@ -1,8 +1,14 @@
 ## opal.models.Patient
 
+### properties
+
+#### `Patient.demographics`
+
+Returns the relevant Demographics instance for the patient.
+
 ### methods
 
-#### create_episode
+#### `Patient.create_episode()`
 
 Returns a new `Episode` for this patient.
 

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -319,7 +319,7 @@ class EpisodeViewSet(LoginRequiredViewset):
             patient, created = Patient.objects.get_or_create(
                 demographics__hospital_number=hospital_number)
             if created:
-                demographics = patient.demographics
+                demographics = patient.demographics()
                 demographics.hospital_number = hospital_number
                 demographics.save()
         else:

--- a/opal/core/api.py
+++ b/opal/core/api.py
@@ -319,7 +319,7 @@ class EpisodeViewSet(LoginRequiredViewset):
             patient, created = Patient.objects.get_or_create(
                 demographics__hospital_number=hospital_number)
             if created:
-                demographics = patient.demographics_set.get()
+                demographics = patient.demographics
                 demographics.hospital_number = hospital_number
                 demographics.save()
         else:

--- a/opal/core/pathway/tests/test_pathways.py
+++ b/opal/core/pathway/tests/test_pathways.py
@@ -232,7 +232,7 @@ class TestSavePathway(PathwayTestCase):
 
     def test_existing_patient_new_episode_save(self):
         patient, episode = self.new_patient_and_episode_please()
-        demographics = patient.demographics
+        demographics = patient.demographics()
         demographics.hospital_number = "1231232"
         demographics.save()
 
@@ -252,7 +252,7 @@ class TestSavePathway(PathwayTestCase):
         patient, episode = self.new_patient_and_episode_please()
         post_data = {"demographics": [{"hospital_number": "101"}]}
         pathway.save(data=post_data, user=self.user, patient=patient)
-        demographics = patient.demographics
+        demographics = patient.demographics()
         self.assertEqual(
             demographics.hospital_number,
             "101"
@@ -272,7 +272,7 @@ class TestSavePathway(PathwayTestCase):
 
     def test_existing_patient_existing_episode_save(self):
         patient, episode = self.new_patient_and_episode_please()
-        demographics = patient.demographics
+        demographics = patient.demographics()
         demographics.hospital_number = "1231232"
         demographics.save()
         url = reverse(

--- a/opal/core/pathway/tests/test_pathways.py
+++ b/opal/core/pathway/tests/test_pathways.py
@@ -232,7 +232,7 @@ class TestSavePathway(PathwayTestCase):
 
     def test_existing_patient_new_episode_save(self):
         patient, episode = self.new_patient_and_episode_please()
-        demographics = patient.demographics_set.get()
+        demographics = patient.demographics
         demographics.hospital_number = "1231232"
         demographics.save()
 
@@ -252,7 +252,7 @@ class TestSavePathway(PathwayTestCase):
         patient, episode = self.new_patient_and_episode_please()
         post_data = {"demographics": [{"hospital_number": "101"}]}
         pathway.save(data=post_data, user=self.user, patient=patient)
-        demographics = patient.demographics_set.get()
+        demographics = patient.demographics
         self.assertEqual(
             demographics.hospital_number,
             "101"
@@ -272,7 +272,7 @@ class TestSavePathway(PathwayTestCase):
 
     def test_existing_patient_existing_episode_save(self):
         patient, episode = self.new_patient_and_episode_please()
-        demographics = patient.demographics_set.get()
+        demographics = patient.demographics
         demographics.hospital_number = "1231232"
         demographics.save()
         url = reverse(

--- a/opal/core/search/queries.py
+++ b/opal/core/search/queries.py
@@ -34,7 +34,7 @@ class PatientSummary(object):
         self.episode_ids = set([episode.id])
         self.patient_id = episode.patient.id
         self.categories = set([episode.category_name])
-        self.id = episode.patient.demographics_set.get().id
+        self.id = episode.patient.demographics.id
 
     def update(self, episode):
         if not self.start:
@@ -421,6 +421,8 @@ class DatabaseQuery(QueryBackend):
 
         for patient_id, patient_summary in patient_summaries.items():
             patient = next(p for p in patients if p.id == patient_id)
+            # Explicitly not using the .demographics property for performance
+            # note that we prefetch demographics_set a few lines earlier
             demographic = patient.demographics_set.get()
 
             result = {k: getattr(demographic, k) for k in [

--- a/opal/core/search/queries.py
+++ b/opal/core/search/queries.py
@@ -34,7 +34,7 @@ class PatientSummary(object):
         self.episode_ids = set([episode.id])
         self.patient_id = episode.patient.id
         self.categories = set([episode.category_name])
-        self.id = episode.patient.demographics.id
+        self.id = episode.patient.demographics().id
 
     def update(self, episode):
         if not self.start:

--- a/opal/core/search/tests/test_search_query.py
+++ b/opal/core/search/tests/test_search_query.py
@@ -78,7 +78,7 @@ class DatabaseQueryTestCase(OpalTestCase):
         self.episode.start = self.DATE_OF_EPISODE
         self.episode.end = self.DATE_OF_EPISODE
         self.episode.save()
-        self.demographics = self.patient.demographics_set.get()
+        self.demographics = self.patient.demographics
         self.demographics.first_name = "Sally"
         self.demographics.surname = "Stevens"
         self.demographics.sex = "Female"
@@ -344,7 +344,7 @@ class DatabaseQueryTestCase(OpalTestCase):
         )
         unknown = Gender(name='Unknown')
         unknown.save()
-        demographics = self.patient.demographics_set.first()
+        demographics = self.patient.demographics
         demographics.sex = 'Unknown'
         demographics.save()
         query = queries.DatabaseQuery(self.user, [criteria])
@@ -357,7 +357,7 @@ class DatabaseQueryTestCase(OpalTestCase):
         )
         unknown = Gender(name='Unknown')
         unknown.save()
-        demographics = self.patient.demographics_set.first()
+        demographics = self.patient.demographics
         demographics.sex = 'Unknown'
         demographics.save()
         query = queries.DatabaseQuery(self.user, [criteria])
@@ -688,7 +688,7 @@ class DatabaseQueryTestCase(OpalTestCase):
         female = Gender.objects.create(name="Female")
         ct = ContentType.objects.get_for_model(Gender)
         Synonym.objects.create(content_type=ct, name="F", object_id=female.id)
-        demographics = self.patient.demographics_set.get()
+        demographics = self.patient.demographics
         demographics.sex = "F"
         demographics.save()
         self.assertEqual("Female", demographics.sex)

--- a/opal/core/search/tests/test_search_query.py
+++ b/opal/core/search/tests/test_search_query.py
@@ -78,7 +78,7 @@ class DatabaseQueryTestCase(OpalTestCase):
         self.episode.start = self.DATE_OF_EPISODE
         self.episode.end = self.DATE_OF_EPISODE
         self.episode.save()
-        self.demographics = self.patient.demographics
+        self.demographics = self.patient.demographics()
         self.demographics.first_name = "Sally"
         self.demographics.surname = "Stevens"
         self.demographics.sex = "Female"
@@ -344,7 +344,7 @@ class DatabaseQueryTestCase(OpalTestCase):
         )
         unknown = Gender(name='Unknown')
         unknown.save()
-        demographics = self.patient.demographics
+        demographics = self.patient.demographics()
         demographics.sex = 'Unknown'
         demographics.save()
         query = queries.DatabaseQuery(self.user, [criteria])
@@ -357,7 +357,7 @@ class DatabaseQueryTestCase(OpalTestCase):
         )
         unknown = Gender(name='Unknown')
         unknown.save()
-        demographics = self.patient.demographics
+        demographics = self.patient.demographics()
         demographics.sex = 'Unknown'
         demographics.save()
         query = queries.DatabaseQuery(self.user, [criteria])
@@ -688,7 +688,7 @@ class DatabaseQueryTestCase(OpalTestCase):
         female = Gender.objects.create(name="Female")
         ct = ContentType.objects.get_for_model(Gender)
         Synonym.objects.create(content_type=ct, name="F", object_id=female.id)
-        demographics = self.patient.demographics
+        demographics = self.patient.demographics()
         demographics.sex = "F"
         demographics.save()
         self.assertEqual("Female", demographics.sex)

--- a/opal/core/search/tests/test_views.py
+++ b/opal/core/search/tests/test_views.py
@@ -19,7 +19,7 @@ class BaseSearchTestCase(OpalTestCase):
 
     def create_patient(self, first_name, last_name, hospital_number):
         patient, episode = self.new_patient_and_episode_please()
-        demographics = patient.demographics
+        demographics = patient.demographics()
         demographics.first_name = first_name
         demographics.surname = last_name
         demographics.hospital_number = hospital_number
@@ -86,7 +86,7 @@ class PatientSearchTestCase(BaseSearchTestCase):
         self.assertEqual(expected, data)
 
     def test_patient_number_with_hash(self):
-        demographics = self.patient.demographics
+        demographics = self.patient.demographics()
         demographics.hospital_number = "#007"
         demographics.save()
         url = '/search/patient/?hospital_number=%23007'
@@ -97,7 +97,7 @@ class PatientSearchTestCase(BaseSearchTestCase):
         self.assertEqual(expected, data)
 
     def test_patient_number_with_slash(self):
-        demographics = self.patient.demographics
+        demographics = self.patient.demographics()
         demographics.hospital_number = "/007"
         demographics.save()
         url = '/search/patient/?hospital_number=%2F007'
@@ -108,7 +108,7 @@ class PatientSearchTestCase(BaseSearchTestCase):
         self.assertEqual(expected, data)
 
     def test_patient_number_with_question_mark(self):
-        demographics = self.patient.demographics
+        demographics = self.patient.demographics()
         demographics.hospital_number = "?007"
         demographics.save()
         url = '/search/patient/?hospital_number=%3F007'
@@ -119,7 +119,7 @@ class PatientSearchTestCase(BaseSearchTestCase):
         self.assertEqual(expected, data)
 
     def test_patient_number_with_ampersand(self):
-        demographics = self.patient.demographics
+        demographics = self.patient.demographics()
         demographics.hospital_number = "&007"
         demographics.save()
         url = '/search/patient/?hospital_number=%26007'

--- a/opal/core/search/tests/test_views.py
+++ b/opal/core/search/tests/test_views.py
@@ -19,7 +19,7 @@ class BaseSearchTestCase(OpalTestCase):
 
     def create_patient(self, first_name, last_name, hospital_number):
         patient, episode = self.new_patient_and_episode_please()
-        demographics = patient.demographics_set.get()
+        demographics = patient.demographics
         demographics.first_name = first_name
         demographics.surname = last_name
         demographics.hospital_number = hospital_number
@@ -86,7 +86,9 @@ class PatientSearchTestCase(BaseSearchTestCase):
         self.assertEqual(expected, data)
 
     def test_patient_number_with_hash(self):
-        self.patient.demographics_set.update(hospital_number="#007")
+        demographics = self.patient.demographics
+        demographics.hospital_number = "#007"
+        demographics.save()
         url = '/search/patient/?hospital_number=%23007'
         resp = self.get_response(url)
         data = json.loads(resp.content.decode('UTF-8'))
@@ -95,7 +97,9 @@ class PatientSearchTestCase(BaseSearchTestCase):
         self.assertEqual(expected, data)
 
     def test_patient_number_with_slash(self):
-        self.patient.demographics_set.update(hospital_number="/007")
+        demographics = self.patient.demographics
+        demographics.hospital_number = "/007"
+        demographics.save()
         url = '/search/patient/?hospital_number=%2F007'
         resp = self.get_response(url)
         data = json.loads(resp.content.decode('UTF-8'))
@@ -104,7 +108,9 @@ class PatientSearchTestCase(BaseSearchTestCase):
         self.assertEqual(expected, data)
 
     def test_patient_number_with_question_mark(self):
-        self.patient.demographics_set.update(hospital_number="?007")
+        demographics = self.patient.demographics
+        demographics.hospital_number = "?007"
+        demographics.save()
         url = '/search/patient/?hospital_number=%3F007'
         resp = self.get_response(url)
         data = json.loads(resp.content.decode('UTF-8'))
@@ -113,7 +119,9 @@ class PatientSearchTestCase(BaseSearchTestCase):
         self.assertEqual(expected, data)
 
     def test_patient_number_with_ampersand(self):
-        self.patient.demographics_set.update(hospital_number="&007")
+        demographics = self.patient.demographics
+        demographics.hospital_number = "&007"
+        demographics.save()
         url = '/search/patient/?hospital_number=%26007'
         resp = self.get_response(url)
         data = json.loads(resp.content.decode('UTF-8'))

--- a/opal/management/commands/create_random_data.py
+++ b/opal/management/commands/create_random_data.py
@@ -155,7 +155,7 @@ class PatientGenerator(object):
         )
 
     def create_episode(self, patient):
-        dob = patient.demographics.date_of_birth
+        dob = patient.demographics().date_of_birth
         kwargs = dict(start=date_generator(start_date=dob))
         episode_finished = random.choice([True, False])
 
@@ -171,7 +171,7 @@ class PatientGenerator(object):
         sexes = ['Female', 'Male', 'Not Known', 'Not Specified']
 
         patient                      = models.Patient.objects.create()
-        demographics                 = patient.demographics
+        demographics                 = patient.demographics()
         hospital_number              = random.randint(1000, 2000000)
         hospital_number              = str(hospital_number)
         demographics.first_name      = random.choice(first_names)
@@ -282,7 +282,7 @@ class EpisodeSubrecordGenerator(SubRecordGenerator):
 
     @cached_property
     def start_date(self):
-        return self.episode.patient.demographics.date_of_birth
+        return self.episode.patient.demographics().date_of_birth
 
     def get_instance(self):
         if self.model._is_singleton:
@@ -301,7 +301,7 @@ class PatientSubrecordGenerator(SubRecordGenerator):
 
     @cached_property
     def start_date(self):
-        return self.patient.demographics.date_of_birth
+        return self.patient.demographics().date_of_birth
 
     def get_instance(self):
         if self.model._is_singleton:

--- a/opal/management/commands/create_random_data.py
+++ b/opal/management/commands/create_random_data.py
@@ -155,7 +155,7 @@ class PatientGenerator(object):
         )
 
     def create_episode(self, patient):
-        dob = patient.demographics_set.first().date_of_birth
+        dob = patient.demographics.date_of_birth
         kwargs = dict(start=date_generator(start_date=dob))
         episode_finished = random.choice([True, False])
 
@@ -171,7 +171,7 @@ class PatientGenerator(object):
         sexes = ['Female', 'Male', 'Not Known', 'Not Specified']
 
         patient                      = models.Patient.objects.create()
-        demographics                 = patient.demographics_set.get()
+        demographics                 = patient.demographics
         hospital_number              = random.randint(1000, 2000000)
         hospital_number              = str(hospital_number)
         demographics.first_name      = random.choice(first_names)
@@ -282,7 +282,7 @@ class EpisodeSubrecordGenerator(SubRecordGenerator):
 
     @cached_property
     def start_date(self):
-        return self.episode.patient.demographics_set.first().date_of_birth
+        return self.episode.patient.demographics.date_of_birth
 
     def get_instance(self):
         if self.model._is_singleton:
@@ -301,7 +301,7 @@ class PatientSubrecordGenerator(SubRecordGenerator):
 
     @cached_property
     def start_date(self):
-        return self.patient.demographics_set.first().date_of_birth
+        return self.patient.demographics.date_of_birth
 
     def get_instance(self):
         if self.model._is_singleton:

--- a/opal/management/commands/detect_duplicates.py
+++ b/opal/management/commands/detect_duplicates.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write("Duplicate detection starting...")
-        klass = Patient.objects.all()[0].demographics_set.get().__class__
+        klass = Patient.objects.all()[0].demographics.__class__
         demographics = klass.objects.all()
         patients = Patient.objects.count()
         suspicious = []
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             progress = '({0}% - {1} found)'.format(
                 int(float(i + 1) / patients * 100), len(suspicious)
             )
-            patient_demographics = patient.demographics_set.get()
+            patient_demographics = patient.demographics
             self.stdout.write(
                 '{0} Examining {1} {2}'.format(
                     progress,
@@ -62,15 +62,15 @@ class Command(BaseCommand):
             self.stdout.write("Suspicious Pair:")
 
             msg_1 = '{0} {1} {2}'.format(
-                pair[0].demographics_set.get().first_name,
-                pair[0].demographics_set.get().surname,
+                pair[0].demographics.first_name,
+                pair[0].demographics.surname,
                 pair[0].id
             )
             self.stdout.write(msg_1)
 
             msg_2 = '{0} {1} {2}'.format(
-                pair[1].demographics_set.get().first_name,
-                pair[1].demographics_set.get().surname,
+                pair[1].demographics.first_name,
+                pair[1].demographics.surname,
                 pair[1].id
             )
             self.stdout.write(msg_2)

--- a/opal/management/commands/detect_duplicates.py
+++ b/opal/management/commands/detect_duplicates.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write("Duplicate detection starting...")
-        klass = Patient.objects.all()[0].demographics.__class__
+        klass = Patient.objects.all()[0].demographics().__class__
         demographics = klass.objects.all()
         patients = Patient.objects.count()
         suspicious = []
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             progress = '({0}% - {1} found)'.format(
                 int(float(i + 1) / patients * 100), len(suspicious)
             )
-            patient_demographics = patient.demographics
+            patient_demographics = patient.demographics()
             self.stdout.write(
                 '{0} Examining {1} {2}'.format(
                     progress,
@@ -62,15 +62,15 @@ class Command(BaseCommand):
             self.stdout.write("Suspicious Pair:")
 
             msg_1 = '{0} {1} {2}'.format(
-                pair[0].demographics.first_name,
-                pair[0].demographics.surname,
+                pair[0].demographics().first_name,
+                pair[0].demographics().surname,
                 pair[0].id
             )
             self.stdout.write(msg_1)
 
             msg_2 = '{0} {1} {2}'.format(
-                pair[1].demographics.first_name,
-                pair[1].demographics.surname,
+                pair[1].demographics().first_name,
+                pair[1].demographics().surname,
                 pair[1].id
             )
             self.stdout.write(msg_2)

--- a/opal/models.py
+++ b/opal/models.py
@@ -492,7 +492,7 @@ class Patient(models.Model):
 
     def __unicode__(self):
         try:
-            demographics = self.demographics_set.get()
+            demographics = self.demographics
             return '%s | %s %s' % (
                 demographics.hospital_number,
                 demographics.first_name,
@@ -594,8 +594,7 @@ class Patient(models.Model):
         return d
 
     def update_from_demographics_dict(self, demographics_data, user):
-        demographics = self.demographics_set.get()
-        demographics.update_from_dict(demographics_data, user)
+        self.demographics.update_from_dict(demographics_data, user)
 
     def save(self, *args, **kwargs):
         created = not bool(self.id)
@@ -706,7 +705,7 @@ class Episode(UpdatesFromDictMixin, TrackedModel):
 
     def __unicode__(self):
         try:
-            demographics = self.patient.demographics_set.get()
+            demographics = self.patient.demographics
 
             return '%s | %s | %s' % (demographics.hospital_number,
                                      demographics.name,
@@ -1426,7 +1425,7 @@ class Location(EpisodeSubrecord):
         abstract = True
 
     def __unicode__(self):
-        demographics = self.episode.patient.demographics_set.get()
+        demographics = self.episode.patient.demographics
         return 'Location for {0}({1}) {2} {3} {4} {5}'.format(
             demographics.name,
             demographics.hospital_number,
@@ -1499,7 +1498,7 @@ class Diagnosis(EpisodeSubrecord):
 
     def __unicode__(self):
         return 'Diagnosis for {0}: {1} - {2}'.format(
-            self.episode.patient.demographics_set.get().name,
+            self.episode.patient.demographics.name,
             self.condition,
             self.date_of_diagnosis
         )

--- a/opal/models.py
+++ b/opal/models.py
@@ -492,7 +492,7 @@ class Patient(models.Model):
 
     def __unicode__(self):
         try:
-            demographics = self.demographics
+            demographics = self.demographics()
             return '%s | %s %s' % (
                 demographics.hospital_number,
                 demographics.first_name,
@@ -504,10 +504,9 @@ class Patient(models.Model):
             print(self.id)
             raise
 
-    @property
     def demographics(self):
         """
-        Shortcut property to return this patient's demographics.
+        Shortcut method to return this patient's demographics.
         """
         return self.demographics_set.get()
 
@@ -594,7 +593,7 @@ class Patient(models.Model):
         return d
 
     def update_from_demographics_dict(self, demographics_data, user):
-        self.demographics.update_from_dict(demographics_data, user)
+        self.demographics().update_from_dict(demographics_data, user)
 
     def save(self, *args, **kwargs):
         created = not bool(self.id)
@@ -705,7 +704,7 @@ class Episode(UpdatesFromDictMixin, TrackedModel):
 
     def __unicode__(self):
         try:
-            demographics = self.patient.demographics
+            demographics = self.patient.demographics()
 
             return '%s | %s | %s' % (demographics.hospital_number,
                                      demographics.name,
@@ -1425,7 +1424,7 @@ class Location(EpisodeSubrecord):
         abstract = True
 
     def __unicode__(self):
-        demographics = self.episode.patient.demographics
+        demographics = self.episode.patient.demographics()
         return 'Location for {0}({1}) {2} {3} {4} {5}'.format(
             demographics.name,
             demographics.hospital_number,
@@ -1498,7 +1497,7 @@ class Diagnosis(EpisodeSubrecord):
 
     def __unicode__(self):
         return 'Diagnosis for {0}: {1} - {2}'.format(
-            self.episode.patient.demographics.name,
+            self.episode.patient.demographics().name,
             self.condition,
             self.date_of_diagnosis
         )

--- a/opal/models.py
+++ b/opal/models.py
@@ -504,6 +504,13 @@ class Patient(models.Model):
             print(self.id)
             raise
 
+    @property
+    def demographics(self):
+        """
+        Shortcut property to return this patient's demographics.
+        """
+        return self.demographics_set.get()
+
     def create_episode(self, **kwargs):
         return self.episode_set.create(**kwargs)
 

--- a/opal/tests/test_admin.py
+++ b/opal/tests/test_admin.py
@@ -44,7 +44,7 @@ class UserProfileAdminTestCase(AdminTestCase):
         self.assertTrue(has_perm)
 
     def test_delete_permission_has_created_subrecord(self):
-        dem = self.patient.demographics_set.get()
+        dem = self.patient.demographics
         dem.created_by = self.user
         dem.save()
         request = self.rf.get('/admin/meh/')
@@ -54,7 +54,7 @@ class UserProfileAdminTestCase(AdminTestCase):
         self.assertFalse(has_perm)
 
     def test_delete_permission_has_updated_subrecord(self):
-        dem = self.patient.demographics_set.get()
+        dem = self.patient.demographics
         dem.updated_by = self.user
         dem.save()
         request = self.rf.get('/admin/meh/')

--- a/opal/tests/test_admin.py
+++ b/opal/tests/test_admin.py
@@ -44,7 +44,7 @@ class UserProfileAdminTestCase(AdminTestCase):
         self.assertTrue(has_perm)
 
     def test_delete_permission_has_created_subrecord(self):
-        dem = self.patient.demographics
+        dem = self.patient.demographics()
         dem.created_by = self.user
         dem.save()
         request = self.rf.get('/admin/meh/')
@@ -54,7 +54,7 @@ class UserProfileAdminTestCase(AdminTestCase):
         self.assertFalse(has_perm)
 
     def test_delete_permission_has_updated_subrecord(self):
-        dem = self.patient.demographics
+        dem = self.patient.demographics()
         dem.updated_by = self.user
         dem.save()
         request = self.rf.get('/admin/meh/')

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -629,7 +629,7 @@ class EpisodeTestCase(OpalTestCase):
     def setUp(self):
         super(EpisodeTestCase, self).setUp()
         self.patient, self.episode = self.new_patient_and_episode_please()
-        self.demographics = self.patient.demographics
+        self.demographics = self.patient.demographics()
 
         # add a date to make sure serialisation works as expected
         self.demographics.date_of_birth = date(2010, 1, 1)
@@ -747,7 +747,7 @@ class EpisodeTestCase(OpalTestCase):
         patient = models.Patient.objects.get(
             demographics__hospital_number="9999000999"
         )
-        demographics = patient.demographics
+        demographics = patient.demographics()
         self.assertEqual("Alain", demographics.first_name)
         self.assertEqual("Anderson", demographics.surname)
         self.assertEqual("Male", demographics.sex)

--- a/opal/tests/test_api.py
+++ b/opal/tests/test_api.py
@@ -629,7 +629,7 @@ class EpisodeTestCase(OpalTestCase):
     def setUp(self):
         super(EpisodeTestCase, self).setUp()
         self.patient, self.episode = self.new_patient_and_episode_please()
-        self.demographics = self.patient.demographics_set.get()
+        self.demographics = self.patient.demographics
 
         # add a date to make sure serialisation works as expected
         self.demographics.date_of_birth = date(2010, 1, 1)
@@ -747,7 +747,7 @@ class EpisodeTestCase(OpalTestCase):
         patient = models.Patient.objects.get(
             demographics__hospital_number="9999000999"
         )
-        demographics = patient.demographics_set.get()
+        demographics = patient.demographics
         self.assertEqual("Alain", demographics.first_name)
         self.assertEqual("Anderson", demographics.surname)
         self.assertEqual("Male", demographics.sex)

--- a/opal/tests/test_command_detect_duplicates.py
+++ b/opal/tests/test_command_detect_duplicates.py
@@ -21,13 +21,13 @@ class CommandTestCase(OpalTestCase):
 
     def test_handle_duplicate_names(self):
         p1 = models.Patient.objects.create()
-        d1 = p1.demographics
+        d1 = p1.demographics()
         d1.first_name = 'Jenny'
         d1.surname = 'Smith'
         d1.save()
 
         p2 = models.Patient.objects.create()
-        d2 = p2.demographics
+        d2 = p2.demographics()
         d2.first_name = 'Jenny'
         d2.surname = 'Smith'
         d2.save()
@@ -45,19 +45,19 @@ class CommandTestCase(OpalTestCase):
         Print the duplicate triple once, but not the third instance.
         """
         p1 = models.Patient.objects.create()
-        d1 = p1.demographics
+        d1 = p1.demographics()
         d1.first_name = 'Jenny'
         d1.surname = 'Smith'
         d1.save()
 
         p2 = models.Patient.objects.create()
-        d2 = p2.demographics
+        d2 = p2.demographics()
         d2.first_name = 'Jenny'
         d2.surname = 'Smith'
         d2.save()
 
         p3 = models.Patient.objects.create()
-        d3 = p3.demographics
+        d3 = p3.demographics()
         d3.first_name = 'Jenny'
         d3.surname = 'Smith'
         d3.save()
@@ -73,14 +73,14 @@ class CommandTestCase(OpalTestCase):
 
     def test_handle_duplicate_dobs(self):
         p1 = models.Patient.objects.create()
-        d1 = p1.demographics
+        d1 = p1.demographics()
         d1.first_name = 'Jenny'
         d1.surname = 'Smiths'
         d1.date_of_birth = datetime.date(1934, 2, 2)
         d1.save()
 
         p2 = models.Patient.objects.create()
-        d2 = p2.demographics
+        d2 = p2.demographics()
         d2.first_name = 'Jenny'
         d2.surname = 'Smith'
         d2.date_of_birth = datetime.date(1934, 2, 2)

--- a/opal/tests/test_command_detect_duplicates.py
+++ b/opal/tests/test_command_detect_duplicates.py
@@ -21,13 +21,13 @@ class CommandTestCase(OpalTestCase):
 
     def test_handle_duplicate_names(self):
         p1 = models.Patient.objects.create()
-        d1 = p1.demographics_set.get()
+        d1 = p1.demographics
         d1.first_name = 'Jenny'
         d1.surname = 'Smith'
         d1.save()
 
         p2 = models.Patient.objects.create()
-        d2 = p2.demographics_set.get()
+        d2 = p2.demographics
         d2.first_name = 'Jenny'
         d2.surname = 'Smith'
         d2.save()
@@ -45,19 +45,19 @@ class CommandTestCase(OpalTestCase):
         Print the duplicate triple once, but not the third instance.
         """
         p1 = models.Patient.objects.create()
-        d1 = p1.demographics_set.get()
+        d1 = p1.demographics
         d1.first_name = 'Jenny'
         d1.surname = 'Smith'
         d1.save()
 
         p2 = models.Patient.objects.create()
-        d2 = p2.demographics_set.get()
+        d2 = p2.demographics
         d2.first_name = 'Jenny'
         d2.surname = 'Smith'
         d2.save()
 
         p3 = models.Patient.objects.create()
-        d3 = p3.demographics_set.get()
+        d3 = p3.demographics
         d3.first_name = 'Jenny'
         d3.surname = 'Smith'
         d3.save()
@@ -73,14 +73,14 @@ class CommandTestCase(OpalTestCase):
 
     def test_handle_duplicate_dobs(self):
         p1 = models.Patient.objects.create()
-        d1 = p1.demographics_set.get()
+        d1 = p1.demographics
         d1.first_name = 'Jenny'
         d1.surname = 'Smiths'
         d1.date_of_birth = datetime.date(1934, 2, 2)
         d1.save()
 
         p2 = models.Patient.objects.create()
-        d2 = p2.demographics_set.get()
+        d2 = p2.demographics
         d2.first_name = 'Jenny'
         d2.surname = 'Smith'
         d2.date_of_birth = datetime.date(1934, 2, 2)

--- a/opal/tests/test_managers.py
+++ b/opal/tests/test_managers.py
@@ -72,18 +72,18 @@ class PrefetchTestCase(OpalTestCase):
 class PatientManagerTestCase(OpalTestCase):
     def setUp(self):
         self.patient_1 = Patient.objects.create()
-        self.patient_1.demographics_set.all().update(
-            first_name="je ne",
-            surname="regrette",
-            hospital_number="rien"
-        )
+        demographics1 = self.patient_1.demographics
+        demographics1.first_name="je ne"
+        demographics1.surname="regrette"
+        demographics1.hospital_number="rien"
+        demographics1.save()
 
         self.patient_2 = Patient.objects.create()
-        self.patient_2.demographics_set.all().update(
-            first_name="je joue",
-            surname="au",
-            hospital_number="football"
-        )
+        demographics2 = self.patient_2.demographics
+        demographics2.first_name="je joue"
+        demographics2.surname="au",
+        demographics2.hospital_number="football"
+        demographics2.save()
 
     def test_hospital_number(self):
         """
@@ -152,18 +152,18 @@ class EpisodeManagerTestCase(OpalTestCase):
     def test_search_returns_both_episodes(self):
         self.patient_1, self.episode_1_1 = self.new_patient_and_episode_please()
         self.episode_1_2 = self.patient_1.create_episode()
-        self.patient_1.demographics_set.all().update(
-            first_name="je ne",
-            surname="regrette",
-            hospital_number="rien"
-        )
+        demographics1 = self.patient_1.demographics
+        demographics1.first_name="je ne"
+        demographics1.surname="regrette"
+        demographics1.hospital_number="rien"
+        demographics1.save()
 
         self.patient_2, self.episode_2_1 = self.new_patient_and_episode_please()
-        self.patient_2.demographics_set.all().update(
-            first_name="je joue",
-            surname="au",
-            hospital_number="football"
-        )
+        demographics2 = self.patient_2.demographics
+        demographics2.first_name="je joue"
+        demographics2.surname="au"
+        demographics2.hospital_number="football"
+        demographics2.save()
 
         episodes = Episode.objects.search("je ne")
         expected = set([self.episode_1_1.id, self.episode_1_2.id])

--- a/opal/tests/test_managers.py
+++ b/opal/tests/test_managers.py
@@ -72,14 +72,14 @@ class PrefetchTestCase(OpalTestCase):
 class PatientManagerTestCase(OpalTestCase):
     def setUp(self):
         self.patient_1 = Patient.objects.create()
-        demographics1 = self.patient_1.demographics
+        demographics1 = self.patient_1.demographics()
         demographics1.first_name="je ne"
         demographics1.surname="regrette"
         demographics1.hospital_number="rien"
         demographics1.save()
 
         self.patient_2 = Patient.objects.create()
-        demographics2 = self.patient_2.demographics
+        demographics2 = self.patient_2.demographics()
         demographics2.first_name="je joue"
         demographics2.surname="au",
         demographics2.hospital_number="football"
@@ -152,14 +152,14 @@ class EpisodeManagerTestCase(OpalTestCase):
     def test_search_returns_both_episodes(self):
         self.patient_1, self.episode_1_1 = self.new_patient_and_episode_please()
         self.episode_1_2 = self.patient_1.create_episode()
-        demographics1 = self.patient_1.demographics
+        demographics1 = self.patient_1.demographics()
         demographics1.first_name="je ne"
         demographics1.surname="regrette"
         demographics1.hospital_number="rien"
         demographics1.save()
 
         self.patient_2, self.episode_2_1 = self.new_patient_and_episode_please()
-        demographics2 = self.patient_2.demographics
+        demographics2 = self.patient_2.demographics()
         demographics2.first_name="je joue"
         demographics2.surname="au"
         demographics2.hospital_number="football"

--- a/opal/tests/test_models.py
+++ b/opal/tests/test_models.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from opal import models
-from opal.core import exceptions
+from opal.core import exceptions, subrecords
 from opal.models import (
     Subrecord, Tagging, Patient, InpatientAdmission, Symptom,
 )
@@ -38,6 +38,19 @@ class PatientRecordAccessTestCase(OpalTestCase):
 
 
 class PatientTestCase(OpalTestCase):
+
+    def test_demographics(self):
+        patient = models.Patient.objects.create()
+        self.assertEqual(patient.demographics_set.get(), patient.demographics)
+
+    def test_demographics_does_not_exist(self):
+        # This is one of those things that should not exist, but let's make
+        # doubly sure that we raise an exception if it does happen !
+        patient = models.Patient.objects.create()
+        patient.demographics_set.get().delete()
+        Demographics = subrecords.get_subrecord_from_model_name('Demographics')
+        with self.assertRaises(Demographics.DoesNotExist):
+            demographics = patient.demographics
 
     def test_create_episode(self):
         patient = models.Patient()

--- a/opal/tests/test_models.py
+++ b/opal/tests/test_models.py
@@ -94,7 +94,7 @@ class PatientTestCase(OpalTestCase):
         original_patient.bulk_update(d, self.user)
 
         patient = Patient.objects.get()
-        demographics = patient.demographics_set.get()
+        demographics = patient.demographics
         self.assertEqual(demographics.first_name, "Samantha")
         self.assertEqual(demographics.surname, "Sun")
         self.assertEqual(demographics.hospital_number, "123312")
@@ -141,7 +141,7 @@ class PatientTestCase(OpalTestCase):
         original_patient.bulk_update(d, self.user)
 
         patient = Patient.objects.get()
-        demographics = patient.demographics_set.get()
+        demographics = patient.demographics
         self.assertEqual(demographics.first_name, "Samantha")
         self.assertEqual(demographics.surname, "Sun")
         self.assertEqual(demographics.hospital_number, "123312")
@@ -164,7 +164,7 @@ class PatientTestCase(OpalTestCase):
 
         original_patient.bulk_update(d, self.user)
         self.assertEqual(
-            original_patient.demographics_set.first().hospital_number, ""
+            original_patient.demographics.hospital_number, ""
         )
 
     def test_bulk_update_tagging(self):
@@ -209,7 +209,7 @@ class PatientTestCase(OpalTestCase):
         original_patient.bulk_update(d, self.user)
 
         patient = Patient.objects.get()
-        demographics = patient.demographics_set.get()
+        demographics = patient.demographics
         self.assertEqual(demographics.first_name, "Samantha")
         self.assertEqual(demographics.surname, "Sun")
         self.assertEqual(demographics.hospital_number, "123312")

--- a/opal/tests/test_models.py
+++ b/opal/tests/test_models.py
@@ -41,7 +41,7 @@ class PatientTestCase(OpalTestCase):
 
     def test_demographics(self):
         patient = models.Patient.objects.create()
-        self.assertEqual(patient.demographics_set.get(), patient.demographics)
+        self.assertEqual(patient.demographics_set.get(), patient.demographics())
 
     def test_demographics_does_not_exist(self):
         # This is one of those things that should not exist, but let's make
@@ -50,7 +50,7 @@ class PatientTestCase(OpalTestCase):
         patient.demographics_set.get().delete()
         Demographics = subrecords.get_subrecord_from_model_name('Demographics')
         with self.assertRaises(Demographics.DoesNotExist):
-            demographics = patient.demographics
+            demographics = patient.demographics()
 
     def test_create_episode(self):
         patient = models.Patient()
@@ -94,7 +94,7 @@ class PatientTestCase(OpalTestCase):
         original_patient.bulk_update(d, self.user)
 
         patient = Patient.objects.get()
-        demographics = patient.demographics
+        demographics = patient.demographics()
         self.assertEqual(demographics.first_name, "Samantha")
         self.assertEqual(demographics.surname, "Sun")
         self.assertEqual(demographics.hospital_number, "123312")
@@ -141,7 +141,7 @@ class PatientTestCase(OpalTestCase):
         original_patient.bulk_update(d, self.user)
 
         patient = Patient.objects.get()
-        demographics = patient.demographics
+        demographics = patient.demographics()
         self.assertEqual(demographics.first_name, "Samantha")
         self.assertEqual(demographics.surname, "Sun")
         self.assertEqual(demographics.hospital_number, "123312")
@@ -164,7 +164,7 @@ class PatientTestCase(OpalTestCase):
 
         original_patient.bulk_update(d, self.user)
         self.assertEqual(
-            original_patient.demographics.hospital_number, ""
+            original_patient.demographics().hospital_number, ""
         )
 
     def test_bulk_update_tagging(self):
@@ -209,7 +209,7 @@ class PatientTestCase(OpalTestCase):
         original_patient.bulk_update(d, self.user)
 
         patient = Patient.objects.get()
-        demographics = patient.demographics
+        demographics = patient.demographics()
         self.assertEqual(demographics.first_name, "Samantha")
         self.assertEqual(demographics.surname, "Sun")
         self.assertEqual(demographics.hospital_number, "123312")


### PR DESCRIPTION
Adds a shortcut method for `demographics_set.get()`

I had originally implemented as a property before realising that it would be infuriating to lose the data in this code:

```python
patient.demographics.hospital_number = '1234'
patient.demographics.surname = 'Doe'
patient.demographics.save()
```

Thought about caching the property - but what about race conditions / other updates etc. 