### PR TITLE
Remove warnings 12

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ### 0.13.0 (Major Release)
 
+#### Removes the deprecated Model._title property
+
+Use of `Model._title` to set a display name of a subrecord has issued a warning for several
+releases - this has now been removed and will no longer work.
+
 ### 0.12.0 (Major Release)
 
 #### Misc Changes

--- a/opal/models.py
+++ b/opal/models.py
@@ -895,13 +895,6 @@ class Subrecord(UpdatesFromDictMixin, ToDictMixin, TrackedModel, models.Model):
 
     @classmethod
     def get_display_name(cls):
-        if hasattr(cls, '_title'):
-            w = "_title has been deprecated and will be removed in v0.12.0, "
-            w = w + "please use verbose_name in Meta instead for {}"
-            logging.warning(
-                w.format(cls.__name__)
-            )
-            return cls._title
         if cls._meta.verbose_name.islower():
             return cls._meta.verbose_name.title()
         return cls._meta.verbose_name

--- a/opal/templatetags/panels.py
+++ b/opal/templatetags/panels.py
@@ -65,12 +65,12 @@ def record_timeline(model, whenfield):
     name = camelcase_to_underscore(model.__class__.__name__)
 
     return {
-        'name': name,
-        'editable': True,
-        'title': getattr(model, '_title', name.replace('_', ' ').title()),
+        'name'           : name,
+        'editable'       : True,
+        'title'          : model.__class__.get_display_name(),
         'detail_template': model.__class__.get_detail_template(),
-        'icon': getattr(model, '_icon', None),
-        'whenfield': whenfield,
+        'icon'           : getattr(model, '_icon', None),
+        'whenfield'      : whenfield,
     }
 
 

--- a/opal/tests/models.py
+++ b/opal/tests/models.py
@@ -43,11 +43,13 @@ class HatWearer(models.EpisodeSubrecord):
 
 
 class EntitledHatWearer(models.EpisodeSubrecord):
-    _title = 'Entitled Wearer of Hats'
     _advanced_searchable = False
     _exclude_from_extract = True
 
     name = dmodels.CharField(max_length=200)
+
+    class Meta:
+        verbose_name = 'Entitled Wearer of Hats'
 
 
 class InvisibleHatWearer(models.EpisodeSubrecord):

--- a/opal/tests/test_models.py
+++ b/opal/tests/test_models.py
@@ -283,16 +283,6 @@ class SubrecordTestCase(OpalTestCase):
         ])
         self.assertEqual(result, "found")
 
-    @patch('opal.models.logging')
-    def test_get_display_name_from_property(self, logging):
-        display_name = EntitledHatWearer.get_display_name()
-        self.assertEqual('Entitled Wearer of Hats', display_name)
-        self.assertTrue(logging.warning)
-        logging.warning.assert_called_once_with(
-            "_title has been deprecated and will be removed in v0.12.0, please \
-use verbose_name in Meta instead for EntitledHatWearer"
-        )
-
     def test_get_display_name_from_meta_verbose_name(self):
         self.assertEqual(
             'Invisible Wearer of Hats',

--- a/opal/tests/test_templatetags_panels.py
+++ b/opal/tests/test_templatetags_panels.py
@@ -3,6 +3,8 @@ Tests create_singletons command
 """
 import os
 
+from mock import patch
+
 from django.template import Template, Context
 from opal.core.test import OpalTestCase
 from opal.templatetags import panels
@@ -75,6 +77,7 @@ class RecordPanelTestCase(OpalTestCase):
 
 
 class RecordTimelineTestCase(OpalTestCase):
+
     def test_record_timeline(self):
         expected = dict(
             name='demographics',
@@ -86,6 +89,12 @@ class RecordTimelineTestCase(OpalTestCase):
         )
         result = panels.record_timeline(Demographics(), 'when')
         self.assertEqual(expected, result)
+
+    def test_record_timeline_uses_get_display_name(self):
+        with patch.object(Demographics, 'get_display_name') as display:
+            display.return_value = 'Person Deets'
+            result = panels.record_timeline(Demographics(), 'when')
+            self.assertEqual('Person Deets', result['title'])
 
 
 class TemasPanelTestCase(OpalTestCase):


### PR DESCRIPTION
These should have been removed in v0.12 really, but definitely now.

The original deprecation should probably have caught the `{% timeline_panel %} ` thing :/