### PR TITLE
1582 lookuplist synonyms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ### 0.13.0 (Major Release)
 
+#### Lookuplist data format
+
+Lookuplist entries in data files are no longer required to have an empty synonyms list
+if the entry doesn't have a synonym. This reduces the file size and makes it easier to
+hand craft data files for new applications.
+
 #### Removes the deprecated Model._title property
 
 Use of `Model._title` to set a display name of a subrecord has issued a warning for several

--- a/opal/core/lookuplists.py
+++ b/opal/core/lookuplists.py
@@ -16,7 +16,7 @@ def load_lookuplist_item(model, item):
     instance, created = model.objects.get_or_create(name=item['name'])
     synonyms_created = 0
 
-    for synonym in item['synonyms']:
+    for synonym in item.get('synonyms', []):
         syn, created_synonym = Synonym.objects.get_or_create(
             content_type=content_type,
             object_id=instance.id,

--- a/opal/tests/test_lookuplists.py
+++ b/opal/tests/test_lookuplists.py
@@ -20,6 +20,7 @@ class AbstractLookupListTestCase(OpalTestCase):
 
 
 class LookupListLoadingTestCase(AbstractLookupListTestCase):
+
     def test_create_instance(self):
         data = {"hat": [dict(name="Bowler", synonyms=[])]}
         _, created, _ = load_lookuplist(data)
@@ -44,6 +45,12 @@ class LookupListLoadingTestCase(AbstractLookupListTestCase):
 
     def test_create_instance_and_synonym(self):
         data = {"hat": [dict(name="Bowler", synonyms=["Derby"])]}
+        _, created, synonyms = load_lookuplist(data)
+        self.assertEqual(created, 1)
+        self.assertEqual(synonyms, 1)
+
+    def test_create_instance_allow_no_symptom(self):
+        data = {"hat": [dict(name="Bowler")]}
         _, created, synonyms = load_lookuplist(data)
         self.assertEqual(created, 1)
         self.assertEqual(synonyms, 1)

--- a/opal/tests/test_lookuplists.py
+++ b/opal/tests/test_lookuplists.py
@@ -53,7 +53,7 @@ class LookupListLoadingTestCase(AbstractLookupListTestCase):
         data = {"hat": [dict(name="Bowler")]}
         _, created, synonyms = load_lookuplist(data)
         self.assertEqual(created, 1)
-        self.assertEqual(synonyms, 1)
+        self.assertEqual(synonyms, 0)
 
 
 class LookupListClassTestCase(AbstractLookupListTestCase):


### PR DESCRIPTION
Fixes #1582 

Lookuplist data files shouldn't need all those empty synonym lists - just move on if it's not there rather than raising a `KeyError`