### PR TITLE
Remove Episode.objects.serialised_active

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,6 @@ We no longer include a value for "active_episode_id" as part of the Patient to_d
 This is effectively meaningless since we moved to an episode model that allows for multiple
 concurrent episodes.
 
-
 #### Removes CopyToCategory
 
 Removes the entire CopyToCategory flow from Opal Core. If applications continue to rely on it,
@@ -25,13 +24,18 @@ This includes the API endpoint at `episode/$id/actions/copyto/$category/`, the t
 `copy_to_category.html`, the Angular controller `CopyToCategoryCtrl` and service
 `CopyToCategory` and Subrecord property `_clonable`.
 
-
 #### Lookuplist data format
 
 Lookuplist entries in data files are no longer required to have an empty synonyms list
 if the entry doesn't have a synonym. This reduces the file size and makes it easier to
 hand craft data files for new applications.
 
+#### TaggedPatientList Episode serialisation
+
+Alters the default serialisation of TaggedPatientList serialisation to no longer filter out
+'inactive' episodes. Given that 'active' was always true when an episode had a tag, this
+was effectivly a no-op anyway unless applications were altering the `get_queryset` for
+these patient lists somehow.
 
 #### Removes the deprecated Model._title property
 

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -233,11 +233,6 @@ class TaggedPatientList(PatientList, utils.AbstractBase):
             possible.append("{0}.{1}".format(self.tag, self.subtag))
         return possible
 
-    def to_dict(self, user):
-        # As opposed to general lists, we only ever want active episodes
-        # for tagged lists
-        return self.get_queryset(user=user).serialised_active(user)
-
 
 """
 Sometimes we group lists for display purposes.

--- a/opal/managers.py
+++ b/opal/managers.py
@@ -138,15 +138,3 @@ class EpisodeQueryset(models.QuerySet):
             d['tagging'][0]['id'] = e.id
             serialised.append(d)
         return serialised
-
-    def serialised_active(self, user, **kw):
-        """
-        Return a set of serialised active episodes.
-
-        KWARGS will be passed to the episode filter.
-        """
-        filters = kw.copy()
-        filters['active'] = True
-        episodes = self.filter(**filters)
-        as_dict = self.serialised(user, episodes)
-        return as_dict

--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -384,12 +384,14 @@ class TestTaggedPatientList(OpalTestCase):
         self.assertEqual(set(taglist), expected)
 
     def test_to_dict_inactive_episodes(self):
+        # Older vesions of Opal only serialised active episodes here
+        # Explicitly test to prevent a reversion
         p, e = self.new_patient_and_episode_please()
         e.set_tag_names(['carnivore'], self.user)
         self.assertEqual(e.pk, TaggingTestNotSubTag().to_dict(self.user)[0]['id'])
         e.active = False
         e.save()
-        self.assertEqual(0, len(TaggingTestNotSubTag().to_dict(self.user)))
+        self.assertEqual(1, len(TaggingTestNotSubTag().to_dict(self.user)))
 
 
 class TabbedPatientListGroupTestCase(OpalTestCase):


### PR DESCRIPTION
Alters the default serialisation of TaggedPatientList serialisation to no longer filter out
'inactive' episodes. Given that 'active' was always true when an episode had a tag, this
was effectivly a no-op anyway unless applications were altering the  for
these patient lists somehow.

refs #1578 