### PR TITLE
1527 model column refactoring 13

### DIFF
--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -14,12 +14,12 @@ class Column(object):
         Set up initial properties from either models or explicit arguments
         """
 
-        self.name = name
-        self.title = title
-        self.single = singleton
-        self.icon = icon
-        self.list_limit = limit
-        self.template_path = template_path
+        self.name                 = name
+        self.title                = title
+        self.single               = singleton
+        self.icon                 = icon
+        self.list_limit           = limit
+        self.template_path        = template_path
         self.detail_template_path = detail_template_path
 
         required = ['title', 'template_path']
@@ -28,41 +28,65 @@ class Column(object):
                 raise ValueError(
                     'Column must have a {0}'.format(attr))
 
-    def to_dict(self, **kwargs):
+    def get_template_path(self, patient_list):
+        """
+        Getter method for the template path for this column
+        """
+        return self.template_path
+
+    def get_detail_template_path(self, patient_list):
+        """
+        Getter method for the detail template path for this column
+        """
+        return self.detail_template_path
+
+    def to_dict(self, patient_list=None, **kwargs):
         return dict(
             name=self.name,
             title=self.title,
             single=self.single,
             icon=self.icon,
             list_limit=self.list_limit,
-            template_path=self.template_path,
-            detail_template_path=self.detail_template_path
+            template_path=self.get_template_path(patient_list),
+            detail_template_path=self.get_detail_template_path(patient_list)
         )
 
 
 class ModelColumn(Column):
 
-    def __init__(self, patient_list, model):
+    def __init__(self, model):
         self.model = model
-        self.patient_list = patient_list
+
         from opal.models import Subrecord
         if not issubclass(model, Subrecord):
             raise ValueError('Model must be a opal.models.Subrecord subclass')
 
-        self.name = model.get_api_name()
-        self.title = model.get_display_name()
-        self.single = model._is_singleton
-        self.icon = getattr(model, '_icon', '')
+        self.name       = model.get_api_name()
+        self.title      = model.get_display_name()
+        self.single     = model._is_singleton
+        self.icon       = getattr(model, '_icon', '')
         self.list_limit = getattr(model, '_list_limit', None)
-        self.template_path = model.get_display_template(
-            prefixes=self.patient_list().get_template_prefixes()
-        )
-        self.detail_template_path = model.get_detail_template(
-            prefixes=self.patient_list().get_template_prefixes()
+
+    def get_template_path(self, patient_list):
+        """
+        Getter method for the template path for this column
+        """
+        return self.model.get_display_template(
+            patient_list().get_template_prefixes()
         )
 
-    def to_dict(self, **kwargs):
-        dicted = super(ModelColumn, self).to_dict(**kwargs)
+    def get_detail_template_path(self, patient_list):
+        """
+        Getter method for the detail template path for this column
+        """
+        return self.model.get_detail_template(
+            prefixes=patient_list().get_template_prefixes()
+        )
+
+    def to_dict(self, patient_list=None, **kwargs):
+        dicted = super(ModelColumn, self).to_dict(
+            patient_list=patient_list, **kwargs
+        )
         dicted['model_column'] = True
         return dicted
 
@@ -154,7 +178,7 @@ class PatientList(discoverable.DiscoverableFeature,
             if isinstance(column, Column):
                 columns.append(column.to_dict())
             else:
-                columns.append(ModelColumn(klass, column).to_dict())
+                columns.append(ModelColumn(column).to_dict(patient_list=klass))
         return columns
 
     @property

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -182,7 +182,6 @@ class PatientList(discoverable.DiscoverableFeature,
                 columns.append(ModelColumn(column).to_dict(patient_list=klass))
         return columns
 
-
     @property
     def queryset(self):
         raise ValueError("this needs to be implemented")

--- a/opal/core/patient_lists.py
+++ b/opal/core/patient_lists.py
@@ -161,8 +161,9 @@ class PatientList(discoverable.DiscoverableFeature,
         )
 
     def get_template_prefixes(self):
-        """ a patient list can return templates particular to themselves
-            or indeed used by other patient lists
+        """
+        A patient list can return templates particular to themselves
+        or indeed used by other patient lists
         """
         return []
 
@@ -180,6 +181,7 @@ class PatientList(discoverable.DiscoverableFeature,
             else:
                 columns.append(ModelColumn(column).to_dict(patient_list=klass))
         return columns
+
 
     @property
     def queryset(self):

--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -139,25 +139,85 @@ class ColumnTestCase(OpalTestCase):
         with self.assertRaises(ValueError):
             patient_lists.Column(title='Foo', name='foo')
 
+    def test_get_template_path(self):
+        c = patient_lists.Column(
+            name='foo',
+            title='Foo',
+            singleton=True,
+            icon='fa-ya',
+            limit=5,
+            template_path='foo/bar',
+            detail_template_path='car/dar'
+        )
+        value = c.get_template_path(MagicMock('Mock Patient List'))
+        self.assertEqual('foo/bar', value)
+
+    def test_get_detail_template_path(self):
+        c = patient_lists.Column(
+            name='foo',
+            title='Foo',
+            singleton=True,
+            icon='fa-ya',
+            limit=5,
+            template_path='foo/bar',
+            detail_template_path='car/dar'
+        )
+        value = c.get_detail_template_path(MagicMock('Mock Patient List'))
+        self.assertEqual('car/dar', value)
+
+    def test_to_dict(self):
+        c = patient_lists.Column(
+            name='foo',
+            title='Foo',
+            singleton=True,
+            icon='fa-ya',
+            limit=5,
+            template_path='foo/bar',
+            detail_template_path='car/dar'
+        )
+        as_dict = c.to_dict(MagicMock('Mock Patient List'))
+        self.assertEqual(as_dict['name'], 'foo')
+        self.assertEqual(as_dict['title'], 'Foo')
+        self.assertEqual(as_dict['single'], True)
+        self.assertEqual(as_dict['icon'], 'fa-ya')
+        self.assertEqual(as_dict['list_limit'], 5)
+        self.assertEqual(as_dict['template_path'], 'foo/bar')
+        self.assertEqual(as_dict['detail_template_path'], 'car/dar')
+
+
 class ModelColumnTestCase(OpalTestCase):
 
     def test_sets_model(self):
         c = patient_lists.ModelColumn(
-            MagicMock(name='mock list'),
             models.Demographics
         )
         self.assertEqual(models.Demographics, c.model)
 
     def test_pass_in_not_a_model(self):
         with self.assertRaises(ValueError):
-            patient_lists.ModelColumn(None, OpalTestCase)
+            patient_lists.ModelColumn(OpalTestCase)
 
     def test_to_dict_sets_model_column(self):
         c = patient_lists.ModelColumn(
-            MagicMock(name='mock list'),
             models.Demographics
         )
-        self.assertEqual(True, c.to_dict()['model_column'])
+        as_dict = c.to_dict(MagicMock('Mock Patient List'))
+        self.assertEqual(True, as_dict['model_column'])
+
+    def test_get_template_path(self):
+        c = patient_lists.ModelColumn(
+            models.Demographics
+        )
+        value = c.get_template_path(MagicMock('Mock Patient List'))
+        self.assertEqual('records/demographics.html', value)
+
+    def test_get_detail_template_path(self):
+        c = patient_lists.ModelColumn(
+            models.Demographics
+        )
+        value = c.get_detail_template_path(MagicMock('Mock Patient List'))
+        self.assertEqual('records/demographics_detail.html', value)
+
 
 
 class TestPatientList(OpalTestCase):


### PR DESCRIPTION
It is currently impossible to usefully override a ModelColumn.

To include a concrete instance of `MyModelColumn(models.Demographics)` in the `schema` attribute of a `PatientList` requires that the ModelColumn no longer require the list class to be passed in at initialization time.

This closes #1527 