### PR TITLE
1474 swap default date display

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ for display according to the setting `DATE_DISPLAY_FORMAT`. This defaults to `D 
 
 New applications will have this setting in their scaffold, existing applications may wish to add it.
 
+All core Opal templates that previously used `shortDate` or `shortDateTime` have been updated to
+use `displayDateX`.
+
 #### Removes scope.jumpToEpisode and scope.getEpisodeId from Search and Extract
 
 We no longer use these functions, instead we use an HTML link to the patient detail view.

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ for display according to the setting `DATE_DISPLAY_FORMAT`. This defaults to `D 
 New applications will have this setting in their scaffold, existing applications may wish to add it.
 
 All core Opal templates that previously used `shortDate` or `shortDateTime` have been updated to
-use `displayDateX`.
+use `displayDate`.
 
 #### Removes scope.jumpToEpisode and scope.getEpisodeId from Search and Extract
 

--- a/doc/docs/reference/panels_templatetags.md
+++ b/doc/docs/reference/panels_templatetags.md
@@ -49,7 +49,7 @@ another but the data is not naturally tabular.
 
 ```html
 {% load panels %}
-{% aligned_pair model="episode.start_date | shortDate" label="Start Date" %}
+{% aligned_pair model="episode.start_date | displayDate" label="Start Date" %}
 {% aligned_pair model="22" label="Next Data Point" %}
 ```
 

--- a/doc/docs/tutorial.md
+++ b/doc/docs/tutorial.md
@@ -188,7 +188,7 @@ Let's take a look at what that did:
 The default detail template simply displays each field on a new line:
 
     <span ng-show="item.job">[[ item.job ]] <br /></span>
-    <span ng-show="item.due_date">[[ item.due_date  | shortDate ]] <br /></span>
+    <span ng-show="item.due_date">[[ item.due_date  | displayDate ]] <br /></span>
     <span ng-show="item.details">[[ item.details ]] <br /></span>
     <span ng-show="item.completed">[[ item.completed ]] <br /></span>
 

--- a/opal/core/pathway/static/js/pathway/app.js
+++ b/opal/core/pathway/static/js/pathway/app.js
@@ -6,6 +6,7 @@
       'ngRoute',
       'ngProgressLite',
       'ngCookies',
+      'opal.config',
       'opal.filters',
       'opal.services',
       'opal.directives',

--- a/opal/core/pathway/templates/pathway/find_patient_form.html
+++ b/opal/core/pathway/templates/pathway/find_patient_form.html
@@ -63,7 +63,7 @@
         <b>Date of Birth</b>
       </div>
       <div class="col-md-8">
-        [[ demographics.date_of_birth | shortDate ]]
+        [[ demographics.date_of_birth | displayDate ]]
       </div>
     </div>
     <div class="row">

--- a/opal/core/search/static/js/search/app.js
+++ b/opal/core/search/static/js/search/app.js
@@ -6,6 +6,7 @@
       'ngRoute',
       'ngProgressLite',
       'ngCookies',
+      'opal.config',
       'opal.filters',
       'opal.services',
       'opal.directives',

--- a/opal/scaffolding/record_templates/record_display.jinja2
+++ b/opal/scaffolding/record_templates/record_display.jinja2
@@ -3,9 +3,9 @@
    {% if f['type'] == 'null_boolean' or f['type'] == 'boolean' %}
      {{ f['title'] }}
    {% elif f['type'] == 'date' %}
-    [[ item.{{ f['name'] }} | shortDate ]]
+    [[ item.{{ f['name'] }} | displayDate ]]
    {% elif f['type'] == 'date_time' %}
-    [[ item.{{ f['name'] }} | shortDateTime ]]
+    [[ item.{{ f['name'] }} | displayDateTime ]]
    {% elif f['type'] == 'time' %}
     [[ item.{{ f['name'] }} | shortTime ]]
    {% else %}

--- a/opal/templates/_helpers/date_of_birth_field.html
+++ b/opal/templates/_helpers/date_of_birth_field.html
@@ -1,7 +1,7 @@
 <div ng-show="editing.demographics.external_system" class="form-group">
   <label class="control-label {% ifequal style "horizontal" %}col-sm-3{% endifequal %}">Date Of Birth</label>
   <p class="form-control-static col-sm-8">
-    [[ {{ model_name }} | shortDate ]]
+    [[ {{ model_name }} | displayDate ]]
   </p>
 </div>
 <div ng-class="{'has-error': form.date_of_birth.$invalid}" ng-hide="editing.demographics.external_system" class="form-group">

--- a/opal/templates/_helpers/static.html
+++ b/opal/templates/_helpers/static.html
@@ -3,6 +3,6 @@
     {{ label }}
   </label>
   <p class="form-control-static col-sm-8">
-    [[ {{ model }}{% if datep %}|shortDate{% endif %} ]]
+    [[ {{ model }}{% if datep %} | displayDate {% endif %} ]]
   </p>
 </div>

--- a/opal/templates/detail/inpatient.html
+++ b/opal/templates/detail/inpatient.html
@@ -4,7 +4,7 @@
     <div class="panel-heading text-center">
       <h3>
         Inpatient admission
-        [[ episode.start | shortDate]]<span ng-show="episode.end"> - [[ episode.end | shortDate ]]</span>
+        [[ episode.start | displayDate ]]<span ng-show="episode.end"> - [[ episode.end | displayDate ]]</span>
       </h3>
     </div>
     <div class="panel-body">
@@ -44,7 +44,7 @@
           <b>Admitted</b>
         </div>
         <div class="col-md-8">
-          [[ episode.start | shortDate ]]
+          [[ episode.start | displayDate ]]
         </div>
       </div>
       <div class="row" ng-show="episode.end">
@@ -52,7 +52,7 @@
           <b>Discharged</b>
         </div>
         <div class="col-md-8">
-          [[ episode.end | shortDate ]]
+          [[ episode.end | displayDate ]]
         </div>
       </div>
       <div class="row">

--- a/opal/templates/layouts/two_column.html
+++ b/opal/templates/layouts/two_column.html
@@ -6,7 +6,7 @@
         <small>
           {% block subheading %}
           [[ episode.demographics[0].hospital_number ]]
-          [[ episode.demographics[0].date_of_birth | shortDate ]]
+          [[ episode.demographics[0].date_of_birth | displayDate ]]
           {% endblock %}
         </small>
       </h1>

--- a/opal/templates/partials/_demographics_panel.html
+++ b/opal/templates/partials/_demographics_panel.html
@@ -37,7 +37,7 @@
         <b>DOB</b>
       </div>
       <div class="col-md-8">
-        [[ patient.demographics[0].date_of_birth | shortDate ]]
+        [[ patient.demographics[0].date_of_birth | displayDate ]]
       </div>
     </div>
     <div class="row">

--- a/opal/templates/partials/_item_created_updated_by.html
+++ b/opal/templates/partials/_item_created_updated_by.html
@@ -4,13 +4,13 @@
       <img class="text-avatar" avatar-for-user="[[ item.created_by_id ]]">
       Created <span ng-show="item.created_by_id">by</span>
       <span full-name-for-user="[[ item.created_by_id ]]"></span>
-      [[ item.created | shortDate]]
+      [[ item.created | displayDate ]]
     </span>
     <span ng-show="item.updated">
       <img class="text-avatar" avatar-for-user="[[ item.updated_by_id ]]">
       Last updated <span ng-show="item.created_by_id">by</span>
       <span full-name-for-user="[[ item.updated_by_id ]]"></span>
-      [[ item.updated | shortDate]]
+      [[ item.updated | displayDate ]]
     </span>
   </p>
 </div>

--- a/opal/templates/partials/_nav_search.html
+++ b/opal/templates/partials/_nav_search.html
@@ -4,7 +4,7 @@
       [[ match.label.first_name ]] [[ match.label.surname ]]
     </h4>
     <span ng-show="match.label.dateOfBirth">
-    ([[ match.label.dateOfBirth | shortDate ]])
+    ([[ match.label.dateOfBirth | displayDate ]])
     </span>
     <div>
       [[ match.label.hospitalNumber ]]

--- a/opal/templates/partials/_patient_summary_list.html
+++ b/opal/templates/partials/_patient_summary_list.html
@@ -17,7 +17,7 @@
             </a>
           </h4>
           <span ng-show="result.dateOfBirth">
-            ([[ result.dateOfBirth | shortDate ]])
+            ([[ result.dateOfBirth | displayDate ]])
           </span>
         </div>
         <div>

--- a/opal/templates/patient_detail_base.html
+++ b/opal/templates/patient_detail_base.html
@@ -20,7 +20,7 @@
         <small>
           {% block subheading %}
           <span ng-show="patient.demographics[0].date_of_birth">
-            ([[ patient.demographics[0].date_of_birth | shortDate ]])
+            ([[ patient.demographics[0].date_of_birth | displayDate ]])
           </span>
           [[ patient.demographics[0].hospital_number ]]
           {% endblock %}
@@ -55,7 +55,7 @@
                    >
                   [[ e.category_name ]]
                   <span ng-show="e.start">
-                    [[ e.start | shortDate ]] - [[ e.end | shortDate ]]<span ng-show="!e.end">Current</span>
+                    [[ e.start | displayDate ]] - [[ e.end | displayDate ]]<span ng-show="!e.end">Current</span>
                   </span>
                 </a>
               </div>

--- a/opal/templates/patient_lists/partials/card_header.html
+++ b/opal/templates/patient_lists/partials/card_header.html
@@ -4,7 +4,7 @@
       <h3><i class="fa fa-user"></i>
         [[ row.demographics[0].first_name ]] [[ row.demographics[0].surname ]] [[ row.demographics[0].hospital_number ]]
         <small>
-          [[ row.demographics[0].date_of_birth|shortDate ]]
+          [[ row.demographics[0].date_of_birth | displayDate ]]
           <span ng-show="row.demographics[0].date_of_birth">
             ([[ row.demographics[0].date_of_birth | age ]])
           </span>

--- a/opal/templates/records/demographics.html
+++ b/opal/templates/records/demographics.html
@@ -1,6 +1,6 @@
 [[item.hospital_number]]<br />
 [[item.first_name]] [[item.surname]]<br />
 <span ng-show="item.date_of_birth">
-  [[item.date_of_birth | shortDate]] ([[ item.date_of_birth | age ]])<br />
+  [[item.date_of_birth | displayDate ]] ([[ item.date_of_birth | age ]])<br />
 </span>
 [[ item.country_of_birth ]] [[ item.ethnicity ]]<br />

--- a/opal/templates/records/demographics_detail.html
+++ b/opal/templates/records/demographics_detail.html
@@ -28,7 +28,7 @@
     <b>DOB</b>
   </div>
   <div class="col-md-8">
-    [[ item.date_of_birth | shortDate ]]
+    [[ item.date_of_birth | displayDate ]]
   </div>
 </div>
 <div class="row">

--- a/opal/templates/records/diagnosis.html
+++ b/opal/templates/records/diagnosis.html
@@ -1,4 +1,4 @@
-[[item.date_of_diagnosis | shortDate]]
+[[item.date_of_diagnosis | displayDate ]]
 <span ng-show="item.provisional">?</span>
 [[item.condition]]
 <span ng-show="item.details">([[item.details]])</span>

--- a/opal/templates/records/inpatient_admission.html
+++ b/opal/templates/records/inpatient_admission.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-6">
-    [[ item.datetime_of_admission | shortDate ]] -
-    <span ng-show="item.datetime_of_discharge">[[ item.datetime_of_discharge | shortDate ]]</span>
+    [[ item.datetime_of_admission | displayDate ]] -
+    <span ng-show="item.datetime_of_discharge">[[ item.datetime_of_discharge | displayDate ]]</span>
     <span ng-hide="item.datetime_of_discharge">current</span>
   </div>
   <div class="col-md-6">

--- a/opal/templates/records/investigation.html
+++ b/opal/templates/records/investigation.html
@@ -1,6 +1,6 @@
 <span class="[[item.date_ordered == null && 'italic']]">
 
-[[item.date_ordered | shortDate]]
+[[item.date_ordered | displayDate ]]
 [[item.test]] <span ng-show="item.details">([[item.details]])</span>
 
 <!-- testType == 'micro_test_other'" -->

--- a/opal/templates/records/patient_consultation.html
+++ b/opal/templates/records/patient_consultation.html
@@ -1,4 +1,4 @@
- <span ng-show="item.when">[[ item.when | shortDate ]] <br /></span>
+ <span ng-show="item.when">[[ item.when | displayDate ]] <br /></span>
  <span ng-show="item.initials">[[ item.initials ]] <br /></span>
  <span ng-show="item.discussion">[[ item.discussion ]] <br /></span>
  <span ng-show="item.reason_for_interaction">[[ item.reason_for_interaction ]] <br /></span>

--- a/opal/templates/records/referral_route.html
+++ b/opal/templates/records/referral_route.html
@@ -1,4 +1,4 @@
- <span ng-show="item.date_of_referral"><b>[[ item.date_of_referral  | shortDate ]]</b></span>
+ <span ng-show="item.date_of_referral"><b>[[ item.date_of_referral  | displayDate ]]</b></span>
  <span ng-show="item.internal">[[ item.internal ]] <br /></span>
  <span ng-show="item.referral_route">[[ item.referral_organisation ]] <br /></span>
  <span ng-show="item.referral_name">[[ item.referral_name ]] <br /></span>

--- a/opal/templates/records/treatment.html
+++ b/opal/templates/records/treatment.html
@@ -1,7 +1,7 @@
 <span ng-class="{'text-muted': item.end_date && (item.end_date | past) }">
   <span ng-show="item.start_date">
-    [[item.start_date | shortDate]]
-    <span ng-show="item.end_date">&ndash;[[item.end_date|shortDate]]</span>
+    [[item.start_date | displayDate ]]
+    <span ng-show="item.end_date">&ndash;[[item.end_date | displayDate ]]</span>
   </span>
   [[item.drug]] [[item.dose]] [[item.route]] [[ item.frequency ]] [[item.delivered_by]]
 </span>

--- a/opal/tests/test_scaffold.py
+++ b/opal/tests/test_scaffold.py
@@ -327,7 +327,7 @@ class RecordRenderTestCase(OpalTestCase):
         scaffold_path = ffs.Path(settings.PROJECT_PATH)/'scaffolding'
         create_display_template_for(Colour, scaffold_path)
         lshift.assert_called_once_with(
-            '<span ng-show="item.name">\n    [[ item.name | shortDateTime ]]\n   <br />\n</span>'
+            '<span ng-show="item.name">\n    [[ item.name | displayDateTime ]]\n   <br />\n</span>'
         )
 
     @patch.object(Colour, "build_field_schema")
@@ -342,7 +342,7 @@ class RecordRenderTestCase(OpalTestCase):
         scaffold_path = ffs.Path(settings.PROJECT_PATH)/'scaffolding'
         create_display_template_for(Colour, scaffold_path)
         lshift.assert_called_once_with(
-            '<span ng-show="item.name">\n    [[ item.name | shortDate ]]\n   <br />\n</span>'
+            '<span ng-show="item.name">\n    [[ item.name | displayDate ]]\n   <br />\n</span>'
         )
 
     @patch.object(Colour, "build_field_schema")

--- a/opal/tests/test_templatetags_forms.py
+++ b/opal/tests/test_templatetags_forms.py
@@ -530,7 +530,7 @@ class StaticTestCase(TestCase):
         tpl = Template('{% load forms %}{% static "Demographics.date_of_birth" %}')
         rendered = tpl.render(Context({}))
         self.assertIn('editing.demographics.date_of_birth', rendered)
-        self.assertIn('shortDate', rendered)
+        self.assertIn('displayDate', rendered)
 
 
 class IconTestCase(TestCase):

--- a/opal/tests/test_templatetags_panels.py
+++ b/opal/tests/test_templatetags_panels.py
@@ -107,9 +107,9 @@ class AlignedPairsTestCase(OpalTestCase):
         template = Template(
             """
             {% load panels %}
-            {% aligned_pair model="episode.start_date | shortDate" label="Start Date"%}
+            {% aligned_pair model="episode.start_date | displayDate" label="Start Date"%}
             """
         )
         result = template.render(Context({}))
-        self.assertIn('[[ episode.start_date | shortDate ]]', result)
+        self.assertIn('[[ episode.start_date | displayDate ]]', result)
         self.assertIn('Start Date', result)


### PR DESCRIPTION
This is item 2/3 in the plan outlined in #1474 

Worth noting that we now have to include `opal.config` in app dependencies to have displayDate render.

As a separate ticket I'm going to suggest adding this to `var implicit_dependencies` in opal/utils.js and removing these explicit includes.