### PR TITLE
Fixup: Don't hardcode paths as they will be different on Windows

### DIFF
--- a/opal/tests/test_patient_lists.py
+++ b/opal/tests/test_patient_lists.py
@@ -209,14 +209,19 @@ class ModelColumnTestCase(OpalTestCase):
             models.Demographics
         )
         value = c.get_template_path(MagicMock('Mock Patient List'))
-        self.assertEqual('records/demographics.html', value)
+        self.assertEqual(
+            ps.path.join('records', 'demographics.html'),
+            value
+        )
 
     def test_get_detail_template_path(self):
         c = patient_lists.ModelColumn(
             models.Demographics
         )
         value = c.get_detail_template_path(MagicMock('Mock Patient List'))
-        self.assertEqual('records/demographics_detail.html', value)
+        self.assertEqual(
+            os.path.join('records', 'demographics_detail.html'),
+            value)
 
 
 


### PR DESCRIPTION
Looking back I think we shouldn't have merged https://github.com/openhealthcare/opal/pull/1617 with failing appveyor tests...