### PR TITLE
1471 admin detail pages

### DIFF
--- a/opal/models.py
+++ b/opal/models.py
@@ -491,18 +491,8 @@ class Patient(models.Model):
     objects = managers.PatientQueryset.as_manager()
 
     def __unicode__(self):
-        try:
-            demographics = self.demographics()
-            return '%s | %s %s' % (
-                demographics.hospital_number,
-                demographics.first_name,
-                demographics.surname
-            )
-        except models.ObjectDoesNotExist:
-            return 'Patient {0}'.format(self.id)
-        except:
-            print(self.id)
-            raise
+        return 'Patient {0}'.format(self.id)
+
 
     def demographics(self):
         """

--- a/opal/models.py
+++ b/opal/models.py
@@ -1394,17 +1394,6 @@ class Location(EpisodeSubrecord):
     class Meta:
         abstract = True
 
-    def __unicode__(self):
-        demographics = self.episode.patient.demographics()
-        return 'Location for {0}({1}) {2} {3} {4} {5}'.format(
-            demographics.name,
-            demographics.hospital_number,
-            self.category,
-            self.hospital,
-            self.ward,
-            self.bed
-        )
-
 
 class Treatment(EpisodeSubrecord):
     _sort = 'start_date'
@@ -1465,13 +1454,6 @@ class Diagnosis(EpisodeSubrecord):
         abstract = True
         verbose_name = 'Diagnosis / Issues'
         verbose_name_plural = "Diagnoses"
-
-    def __unicode__(self):
-        return 'Diagnosis for {0}: {1} - {2}'.format(
-            self.episode.patient.demographics().name,
-            self.condition,
-            self.date_of_diagnosis
-        )
 
 
 class PastMedicalHistory(EpisodeSubrecord):

--- a/opal/models.py
+++ b/opal/models.py
@@ -493,7 +493,6 @@ class Patient(models.Model):
     def __unicode__(self):
         return 'Patient {0}'.format(self.id)
 
-
     def demographics(self):
         """
         Shortcut method to return this patient's demographics.

--- a/opal/models.py
+++ b/opal/models.py
@@ -701,18 +701,9 @@ class Episode(UpdatesFromDictMixin, TrackedModel):
     objects = managers.EpisodeQueryset.as_manager()
 
     def __unicode__(self):
-        try:
-            demographics = self.patient.demographics()
-
-            return '%s | %s | %s' % (demographics.hospital_number,
-                                     demographics.name,
-                                     self.start)
-        except models.ObjectDoesNotExist:
-            return self.start
-        except AttributeError:
-            return 'Episode: {0}'.format(self.pk)
-        except Exception:
-            return self.start
+        return 'Episode {0}: {1} - {2}'.format(
+            self.pk, self.start, self.end
+        )
 
     def save(self, *args, **kwargs):
         created = not bool(self.id)

--- a/opal/tests/test_episode.py
+++ b/opal/tests/test_episode.py
@@ -34,6 +34,10 @@ class EpisodeTest(OpalTestCase):
         episode = self.patient.create_episode()
         self.assertEqual('MyEpisodeCategory', episode.category_name)
 
+    def test__unicode__(self):
+        expected = 'Episode {}: None - None'.format(self.episode.pk)
+        self.assertEqual(expected, self.episode.__unicode__())
+
     def test_category(self):
         self.episode.category_name = 'Inpatient'
         self.assertEqual(self.episode.category.__class__, InpatientEpisode)

--- a/opal/tests/test_patient.py
+++ b/opal/tests/test_patient.py
@@ -16,6 +16,10 @@ class PatientTest(OpalTestCase):
     def test_singleton_subrecord_created(self):
         self.assertEqual(1, self.patient.famouslastwords_set.count())
 
+    def test__unicode__(self):
+        expected = 'Patient {}'.format(self.patient.pk)
+        self.assertEqual(expected, self.patient.__unicode__())
+
     def test_can_create_episode(self):
         episode = self.patient.create_episode()
         self.assertEqual(Episode, type(episode))


### PR DESCRIPTION
The big hit was doing two queries (select patient, select demographics) for every item in the Episode select widget.

This PR kills any __unicode__ methods that made database queries.

closes #1471 