### PR TITLE
Add additional documentation for Episode Category / Patient detail template inheritance.

### DIFF
--- a/doc/docs/guides/episodes.md
+++ b/doc/docs/guides/episodes.md
@@ -43,6 +43,12 @@ print episode.category.detail_template
 # detail/inpatient.html
 ```
 
+The Episode Category template does not comprise the entire
+[Patient detail view](/patient_detail_views.md). This is made of multiple episodes
+and by default will display some basic demographic details as well as other episodes.
+More detail on customising the rest of the detail tempalte is found in the detail view
+[Template selection docs](/patient_detail_views.md#template-selection).
+
 ## Default Category
 
 The default category of episodes in an Opal application is set by the

--- a/doc/docs/guides/episodes.md
+++ b/doc/docs/guides/episodes.md
@@ -44,10 +44,10 @@ print episode.category.detail_template
 ```
 
 The Episode Category template does not comprise the entire
-[Patient detail view](/patient_detail_views.md). This is made of multiple episodes
+[Patient detail view](patient_detail_views.md). This is made of multiple episodes
 and by default will display some basic demographic details as well as other episodes.
 More detail on customising the rest of the detail tempalte is found in the detail view
-[Template selection docs](/patient_detail_views.md#template-selection).
+[Template selection docs](patient_detail_views.md#template-selection).
 
 ## Default Category
 

--- a/doc/docs/guides/topic-guides.md
+++ b/doc/docs/guides/topic-guides.md
@@ -18,7 +18,7 @@ A list of all available topic guides.
 |||
 |---------------------------|--------------------------------------------------------------------|
 |[Data Model](datamodel.md) | How Opal models clinical reality|
-|[Episodes](episodes)|Opal Episodes and how to customise them|
+|[Episodes](episodes.md)|Opal Episodes and how to customise them|
 |[Core Clinical Model](archetypes.md)| The core clinical data model available to Opal applications|
 |[Reference data](referencedata.md) | Canonical coded terms and reference data|
 |[App metadata](metadata.md) | Working with Metadata on the front end  |


### PR DESCRIPTION
Although the ticket talks about template inheritance in general, this PR adds just docs for the part mentioned.

We could definitely use more x-linkage in the docs, and short term happy to add any clarifying sections for any specific things pointed out.

Medium term, completing the theming tutorial (https://opal.openhealthcare.org.uk/docs/tutorials/theming_tutorial/) and / or drastically reducing the role of Angular makes the 'template inheritance' thing go away by reducing the point of ambiguity over 'what is rendering this bit of screen'.

I think this closes that ticket at least as much as we're reasonably likely to write any extensive template inheritance specific docs (not at all likely) in the short term.

closes #1428