### PR TITLE
dummy_options_module.py from the plugin scaffold hasn't been required…

### DIFF
--- a/opal/scaffolding/plugin_scaffold/app/tests/dummy_options_module.py
+++ b/opal/scaffolding/plugin_scaffold/app/tests/dummy_options_module.py
@@ -1,1 +1,0 @@
-model_names = []


### PR DESCRIPTION
… for many moons. Delete it.