### PR TITLE
There is a bug if number of episodes > number of patients, the query …

### DIFF
--- a/opal/core/search/tests/test_views.py
+++ b/opal/core/search/tests/test_views.py
@@ -295,6 +295,29 @@ class SimpleSearchViewTestCase(BaseSearchTestCase):
         }
         self.assertEqual(response, expected)
 
+    @patch('opal.core.search.views.PAGINATION_AMOUNT', 2)
+    def test_patients_more_than_pagination_amount(self):
+        """
+        Prior to 0.16.0 the implementation would sometimes
+        return results with fewer than the number of results
+        that should have been on that page.
+
+        This is because a subquery was paginating by the
+        number of episodes rather than the number of
+        patients.
+        """
+        blofeld_patient, blofeld_episode = self.create_patient(
+            "Ernst", "Blofeld", "23422"
+        )
+        blofeld_patient.create_episode()
+
+        response = json.loads(
+            self.get_response(
+                '{}/?query=o'.format(self.url)
+            ).content.decode('UTF-8')
+        )
+        self.assertEqual(len(response["object_list"]), 2)
+
 
 class SearchTemplateTestCase(OpalTestCase):
 

--- a/opal/core/search/views.py
+++ b/opal/core/search/views.py
@@ -109,8 +109,9 @@ def simple_search_view(request):
     # on postgres it blows up if we don't manually manage this
     if not paginated_patients:
         paginated_patients = models.Patient.objects.none()
+
     episodes = models.Episode.objects.filter(
-        id__in=paginated_patients.values_list("episode__id", flat=True)
+        patient__in=paginated_patients
     )
     paginated["object_list"] = query.get_aggregate_patients_from_episodes(
         episodes


### PR DESCRIPTION
…was paginating the episodes by the number it was paginating the patients. This meant when we built the patient summaries from the episodes we would not have all of the patients showing