### PR TITLE
Pathway was not adding the patient to the api call if episode was not…

### DIFF
--- a/opal/core/pathway/static/js/pathway/services/pathway_loader.js
+++ b/opal/core/pathway/static/js/pathway/services/pathway_loader.js
@@ -5,6 +5,10 @@ angular.module('opal.services')
       	    var deferred = $q.defer();
             url = '/pathway/detail/' + pathwayName;
 
+            if(patientId && !episodeId){
+              url = url + "/" + patientId;
+            }
+
             if(episodeId){
               url = url + "/" + patientId + "/" + episodeId;
             }

--- a/opal/core/pathway/static/js/test/pathway_loader.service.test.js
+++ b/opal/core/pathway/static/js/test/pathway_loader.service.test.js
@@ -26,6 +26,14 @@ describe('pathwayLoader', function() {
     expect(!!result.then).toBe(true);
   });
 
+  it('should add the patient id if the episode id is not provided', function(){
+    $httpBackend.expectGET("/pathway/detail/somePathway/12").respond({});
+    pathwayLoader.load("somePathway", 12);
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingRequest();
+    $httpBackend.verifyNoOutstandingExpectation();
+  });
+
   it('should add the episode id/patient id if provided', function(){
     $httpBackend.expectGET("/pathway/detail/somePathway/12/10").respond({});
     pathwayLoader.load("somePathway", 12, 10);


### PR DESCRIPTION
… present. Note this will still not add the patient to the pathway to dict.

So this will save to the correct patient but will not add serialised patient subrecords to the front end context, so for example demographics would appear empty.

