### PR TITLE
Improves the message when a consistency error is raised.

### DIFF
--- a/opal/models.py
+++ b/opal/models.py
@@ -351,7 +351,9 @@ class UpdatesFromDictMixin(SerialisableFields):
                 )
 
             if consistency_token != self.consistency_token:
-                raise exceptions.ConsistencyError
+                class_name = self.__class__.__name__
+                msg = f"Consistency token error for {class_name} id: {self.id}"
+                raise exceptions.ConsistencyError(msg)
 
         post_save = []
 

--- a/opal/tests/test_models.py
+++ b/opal/tests/test_models.py
@@ -742,6 +742,20 @@ class PatientConsultationTestCase(OpalTestCase):
         patient_consultation = self.episode.patientconsultation_set.first()
         self.assertTrue(patient_consultation.when >= now)
 
+    def test_consistency_token_error(self):
+        self.patient_consultation.set_consistency_token()
+        self.patient_consultation.save()
+        patient_consultation_dict = dict(
+            when='10/06/2016 12:02:20',
+            consistency_token='wrong'
+        )
+        with self.assertRaises(exceptions.ConsistencyError) as m:
+            self.patient_consultation.update_from_dict(patient_consultation_dict, self.user)
+        self.assertEqual(
+            str(m.exception),
+            f'Consistency token error for PatientConsultation id: {self.patient_consultation.id}'
+        )
+
 
 class SymptomComplexTestCase(OpalTestCase):
     def setUp(self):


### PR DESCRIPTION
When a consistency error is raised for an object include the class name and the id