### PR TITLE
Fix a bugin create_random_data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ### 0.24.0 (Major Release)
 
+#### Fixes a sporadic failure in create_random_data
+Fixes a bug where in an edge case create_random.data.date_generator would raise "ValueError: empty range for randrange()".
+
 ### 0.23.0 (Major Release)
 
 #### Enhanced customisation of search results

--- a/opal/management/commands/create_random_data.py
+++ b/opal/management/commands/create_random_data.py
@@ -100,7 +100,7 @@ def date_generator(*args, **kwargs):
     else:
         first_day = 1
 
-    if first_day == last_day:
+    if first_day >= last_day:
         day = first_day
     else:
         day = random.randint(first_day, last_day)


### PR DESCRIPTION
It was possible for the date_generator to error with "ValueError: empty range for randrange()". For a leap year the chance was approximately 1 in 12*88 although this changes with date. This happened when the start date integer entered into random.randint was after the end date integer.

This change makes that chance impossible.